### PR TITLE
fix :verify username screen (#1307)

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/utilities/ODKServicesPropertyUtils.java
+++ b/services_app/src/main/java/org/opendatakit/services/utilities/ODKServicesPropertyUtils.java
@@ -51,9 +51,9 @@ public class ODKServicesPropertyUtils {
          String user_id = props.getProperty(CommonToolProperties.KEY_AUTHENTICATED_USER_ID);
          String roles = props.getProperty(CommonToolProperties.KEY_ROLES_LIST);
          if (name != null && name.length() != 0 &&
-             user_id != null && user_id.length() != 0 &&
-             roles != null && roles.length() != 0) {
-            activeUserName = user_id;
+             user_id != null &&
+             roles != null ) {
+            activeUserName = name;
          } else {
             activeUserName = CommonToolProperties.ANONYMOUS_USER;
          }


### PR DESCRIPTION
Now changing the username in server settings correctly updates the field in verify user screen 

What has been done to verify that this works as intended?
Tested on physical device (Android 7.0) and emulator (Android 7.0 & 8.0) and behaviour found correct


![untitled](https://user-images.githubusercontent.com/19202937/36352179-1782ba0e-14db-11e8-8978-cae70a7a9f89.gif)
