### PR TITLE
Added Constants class to store the value of OdkClientApiVersion

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/sync/service/SyncExecutionContext.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/SyncExecutionContext.java
@@ -39,6 +39,7 @@ import org.opendatakit.properties.PropertiesSingleton;
 import org.opendatakit.properties.PropertyManager;
 import org.opendatakit.services.sync.service.logic.Synchronizer;
 import org.opendatakit.services.sync.service.logic.Synchronizer.SynchronizerStatus;
+import org.opendatakit.services.utilities.Constants;
 import org.opendatakit.sync.service.SyncOutcome;
 import org.opendatakit.sync.service.SyncOverallResult;
 import org.opendatakit.sync.service.SyncProgressState;
@@ -68,13 +69,9 @@ public class SyncExecutionContext implements SynchronizerStatus {
   private int nMajorSyncSteps;
   private int iMajorSyncStep;
   private int GRAINS_PER_MAJOR_SYNC_STEP;
-
   private final Context application;
-  private final String versionCode;
   private final String appName;
-  private final String odkClientApiVersion;
   private final String userAgent;
-
   private final String aggregateUri;
   private final String authenticationType;
   private final String username;
@@ -96,8 +93,6 @@ public class SyncExecutionContext implements SynchronizerStatus {
       SyncOverallResult syncResult) {
     this.application = context;
     this.appName = appName;
-    this.versionCode = versionCode;
-    this.odkClientApiVersion = versionCode.substring(0, versionCode.length() - 2);
     this.userAgent = "Sync " + versionCode + " (gzip)";
     this.syncProgressTracker = syncProgressTracker;
     this.synchronizer = null;
@@ -206,7 +201,7 @@ public class SyncExecutionContext implements SynchronizerStatus {
   }
 
   public String getOdkClientApiVersion() {
-    return this.odkClientApiVersion;
+    return Constants.ODK_CLIENT_API_VERSION;
   }
 
   public String getUserAgent() {

--- a/services_app/src/main/java/org/opendatakit/services/utilities/Constants.java
+++ b/services_app/src/main/java/org/opendatakit/services/utilities/Constants.java
@@ -1,0 +1,13 @@
+package org.opendatakit.services.utilities;
+
+/**
+ * Utility class for storing Constants used throughout the project.
+ *
+ * @author Jaishree
+ *
+ */
+public class Constants {
+
+    public static final String ODK_CLIENT_API_VERSION = "2";
+
+}


### PR DESCRIPTION
Added a Constants class to store the value of OdkClientApiVersion.

This class can be used to store other constants which are being used in other places as well so that the code becomes more modularized.

Fixes [#150](https://github.com/odk-x/tool-suite-X/issues/150) 