### PR TITLE
Changed url of user documentation in strings.xml from http://opendatakit.org to https://docs.odk-x.org

### DIFF
--- a/services_app/src/main/res/values-es/strings.xml
+++ b/services_app/src/main/res/values-es/strings.xml
@@ -247,8 +247,8 @@
     <string name="general_settings">Confirguraciones generales</string>
     <string name="admin_general_settings">Acceso de administrador a la configuración</string>
     <string name="opendatakit_website">Odk Documentación para usuario</string>
-    <string name="click_to_web">Has clic para visitar http://opendatakit.org</string>
-    <string name="opendatakit_url">http://opendatakit.org</string>
+    <string name="click_to_web">Has clic para visitar https://docs.odk-x.org</string>
+    <string name="opendatakit_url">https://docs.odk-x.org</string>
     <string name="server_settings_summary">Usuario, autenticación y configuración del servidor</string>
     <string name="server">Configuración del servidor</string>
     <string name="server_restrictions_apply">Configuración del servidor (Aplicación de restricciones para no administradores)</string>

--- a/services_app/src/main/res/values/strings.xml
+++ b/services_app/src/main/res/values/strings.xml
@@ -299,8 +299,8 @@
     <string name="general_settings">General Settings</string>
     <string name="admin_general_settings">Admin Access to Settings</string>
     <string name="opendatakit_website">Open Data Kit user documentation</string>
-    <string name="click_to_web">Tap to visit http://opendatakit.org</string>
-    <string name="opendatakit_url">http://opendatakit.org</string>
+    <string name="click_to_web">Tap to visit https://docs.odk-x.org</string>
+    <string name="opendatakit_url">https://docs.odk-x.org</string>
 
     <string name="server_settings_summary">User Identity, Authentication and Server Configuration</string>
     <string name="server">Server Settings</string>


### PR DESCRIPTION
Screenshot of settings page:

![image](https://user-images.githubusercontent.com/58835654/111297801-0ac5de00-8674-11eb-8212-949515a12f02.png)

fixes [#203](https://github.com/odk-x/tool-suite-X/issues/203)
