### PR TITLE
Crashing of app fixed due to code error in previous PR

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/sync/actions/fragments/SyncFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/actions/fragments/SyncFragment.java
@@ -142,9 +142,10 @@ public class SyncFragment extends AbsSyncUIFragment {
 
     syncInstanceAttachmentsSpinner = view.findViewById(R.id.sync_instance_attachments);
     lastSyncField = view.findViewById(R.id.last_sync_field);
-    displayLastSyncInfo();
+
 
     properties = CommonToolProperties.get(this.getContext(),getAppName());
+    displayLastSyncInfo();
     if(properties.containsKey(CommonToolProperties.KEY_SYNC_ATTACHMENT_STATE) && properties.getProperty(CommonToolProperties.KEY_SYNC_ATTACHMENT_STATE) != null){
       String state = properties.getProperty(CommonToolProperties.KEY_SYNC_ATTACHMENT_STATE);
       try {


### PR DESCRIPTION
The method displayLastSyncInfo() must be called once PropertiesSingleton is initialized. The mistake happened while fixing the merge conflicts in previous PR #184.
I am sorry for inconvenience.