### PR TITLE
Fix null pointer in FormsProvider

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/forms/provider/FormsProvider.java
+++ b/services_app/src/main/java/org/opendatakit/services/forms/provider/FormsProvider.java
@@ -94,6 +94,10 @@ public class FormsProvider extends ContentProvider {
   }
 
   private boolean isNumeric(final CharSequence charSequence) {
+    if (charSequence == null) {
+      return false;
+    }
+
     int size = charSequence.length();
     if (size == 0) {
       return false;


### PR DESCRIPTION
The lang3 `isNumeric` method returns `false` when the input is null. This pull request adds a null check and returns false when the input is null.

lang3's implementation https://github.com/apache/commons-lang/blob/d1e9e598c9bcbf91afa174fa9b6c2ef30bbc8157/src/main/java/org/apache/commons/lang3/StringUtils.java#L3743-L3785