### PR TITLE
Fix#221: Crashing of sync fragment fixed

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/sync/actions/fragments/SyncFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/actions/fragments/SyncFragment.java
@@ -132,20 +132,10 @@ public class SyncFragment extends AbsSyncUIFragment {
     disableButtons();
   }
 
-  @Override public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-    super.onCreateView(inflater, container, savedInstanceState);
-
-    View view = inflater.inflate(ID, container, false);
-
-    infoPane = view.findViewById(R.id.sync_info_pane);
-    populateTextViewMemberVariablesReferences(view);
-
-    syncInstanceAttachmentsSpinner = view.findViewById(R.id.sync_instance_attachments);
-    lastSyncField = view.findViewById(R.id.last_sync_field);
-
-
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
     properties = CommonToolProperties.get(this.getContext(),getAppName());
-    displayLastSyncInfo();
     if(properties.containsKey(CommonToolProperties.KEY_SYNC_ATTACHMENT_STATE) && properties.getProperty(CommonToolProperties.KEY_SYNC_ATTACHMENT_STATE) != null){
       String state = properties.getProperty(CommonToolProperties.KEY_SYNC_ATTACHMENT_STATE);
       try {
@@ -153,7 +143,19 @@ public class SyncFragment extends AbsSyncUIFragment {
       } catch (IllegalArgumentException e) {
         syncAttachmentState = SyncAttachmentState.SYNC;
       }
-    } else syncAttachmentState = SyncAttachmentState.SYNC;
+    }
+  }
+
+  @Override public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    super.onCreateView(inflater, container, savedInstanceState);
+
+    View view = inflater.inflate(ID, container, false);
+
+    infoPane = view.findViewById(R.id.sync_info_pane);
+    populateTextViewMemberVariablesReferences(view);
+    syncInstanceAttachmentsSpinner = view.findViewById(R.id.sync_instance_attachments);
+    lastSyncField = view.findViewById(R.id.last_sync_field);
+    displayLastSyncInfo();
 
     if (savedInstanceState != null && savedInstanceState.containsKey(SYNC_ATTACHMENT_TREATMENT)) {
       String treatment = savedInstanceState.getString(SYNC_ATTACHMENT_TREATMENT);


### PR DESCRIPTION
fixes: https://github.com/odk-x/tool-suite-X/issues/221

**Reason for crash:** variable syncAttachmentState wasn't being initialized before using in onSavedInstanceState(). This was particularly happening when the  about screen was opened and the device was being rotated twice. It is happening because the syncAttachmentState is initialized in onCreateView() method which is not called in this particular case because fragment isn't visible, but savedInstance state is called upon second rotation and app crashes.

**Solution:** syncAttachmentState is initialized in onCreate() method of fragment instead of onCreateView().

**P.S:** It is not possible to initialize this variable globally as done earlier, because then the sync type spinner's selected index won't be saved in the particular case stated above, but since onCreate() will always be called before onSaveInstanceState() problem is solved.