### PR TITLE
Fixed Null Pointer on Rotating Screen in Settings

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/preferences/fragments/AbsAdminConfigurableSettingsFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/fragments/AbsAdminConfigurableSettingsFragment.java
@@ -1,7 +1,10 @@
 package org.opendatakit.services.preferences.fragments;
 
 import android.os.Bundle;
+import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.XmlRes;
 import androidx.preference.CheckBoxPreference;
 import androidx.preference.Preference;
@@ -27,7 +30,11 @@ public abstract class AbsAdminConfigurableSettingsFragment extends PreferenceFra
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+  }
 
+  @Override
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
     initializeCheckBoxPreference(getPreferenceScreen());
   }
 

--- a/services_app/src/main/java/org/opendatakit/services/preferences/fragments/TablesSettingsFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/fragments/TablesSettingsFragment.java
@@ -15,7 +15,10 @@
 package org.opendatakit.services.preferences.fragments;
 
 import android.os.Bundle;
+import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.preference.CheckBoxPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
@@ -44,7 +47,11 @@ public class TablesSettingsFragment extends PreferenceFragmentCompat {
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+  }
 
+  @Override
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
     PropertiesSingleton props = ((IOdkAppPropertiesActivity) this.getActivity()).getProps();
 
     // not super safe, but we're just putting in this mode to help
@@ -52,14 +59,14 @@ public class TablesSettingsFragment extends PreferenceFragmentCompat {
     // would require code to access it
     boolean adminMode;
     adminMode = (this.getArguments() == null) ? false :
-        (this.getArguments().containsKey(IntentConsts.INTENT_KEY_SETTINGS_IN_ADMIN_MODE) ?
-            this.getArguments().getBoolean(IntentConsts.INTENT_KEY_SETTINGS_IN_ADMIN_MODE) : false);
+            (this.getArguments().containsKey(IntentConsts.INTENT_KEY_SETTINGS_IN_ADMIN_MODE) ?
+                    this.getArguments().getBoolean(IntentConsts.INTENT_KEY_SETTINGS_IN_ADMIN_MODE) : false);
 
     String adminPwd = props.getProperty(CommonToolProperties.KEY_ADMIN_PW);
     boolean adminConfigured = (adminPwd != null && adminPwd.length() != 0);
 
     PreferenceCategory deviceCategory = findPreference
-        (CommonToolProperties.GROUPING_TOOL_TABLES_CATEGORY);
+            (CommonToolProperties.GROUPING_TOOL_TABLES_CATEGORY);
 
     Boolean useHomeScreen = props.getBooleanProperty(CommonToolProperties.KEY_CHANGE_USE_HOME_SCREEN);
     useHomeScreen = (useHomeScreen == null) ? false : useHomeScreen;
@@ -76,7 +83,7 @@ public class TablesSettingsFragment extends PreferenceFragmentCompat {
       @Override
       public boolean onPreferenceChange(Preference preference, Object newValue) {
         PropertiesSingleton props = ((IOdkAppPropertiesActivity)
-            TablesSettingsFragment.this.getActivity()).getProps();
+                TablesSettingsFragment.this.getActivity()).getProps();
         props.setProperties(Collections.singletonMap(preference.getKey(), newValue.toString()));
         return true;
       }


### PR DESCRIPTION
**Issue Reference**: https://github.com/odk-x/tool-suite-X/issues/227

**Reason for Crash**:
- During the Screen Rotation, the `AppPropertiesActivity` was first being destroyed and then created again.
- Subsequently, the respective Preference Fragments were also being destroyed and created.
- During this, the `onCreate` method of these fragments was called even when the `onCreate` method of `AppPropertiesActivity` was not completed [(Reference from Google Developer's Website](https://developer.android.com/reference/androidx/preference/PreferenceFragmentCompat#onCreate(android.os.Bundle))).
- Because of this the `mAppName` and `mProps` variables of `AppPropertiesActivity` were being called even before they were initialized, thus leading to a **NullPointerException**.

**Small Description of Changes Performed**:
- Moved the method `initializeCheckBoxPreference` from `onCreate` to `onViewCreated` in `AbsAdminConfigurableSettingsFragment.java`
- Moved the code being executed in `onCreate` to `onViewCreated` in `TablesSettingsFragment.java`

**PS**: Please Review this PR and suggest any changes required!