### PR TITLE
Bug fix in Authentication Error dialog box

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/sync/actions/activities/AbsSyncBaseActivity.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/actions/activities/AbsSyncBaseActivity.java
@@ -317,7 +317,7 @@ public abstract class AbsSyncBaseActivity extends AppCompatActivity
       builder.setMessage(message);
       builder.setNeutralButton(android.R.string.ok, new DialogInterface.OnClickListener() {
          public void onClick(DialogInterface dialog, int id) {
-            activity.finish();
+//            activity.finish();
             dialog.dismiss();
          }
       });

--- a/services_app/src/main/java/org/opendatakit/services/sync/actions/activities/AbsSyncBaseActivity.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/actions/activities/AbsSyncBaseActivity.java
@@ -40,6 +40,7 @@ import org.opendatakit.activities.IAppAwareActivity;
 import org.opendatakit.consts.IntentConsts;
 import org.opendatakit.fragment.AboutMenuFragment;
 import org.opendatakit.logging.WebLogger;
+import org.opendatakit.logging.desktop.WebLoggerDesktopFactoryImpl;
 import org.opendatakit.properties.CommonToolProperties;
 import org.opendatakit.properties.PropertiesSingleton;
 import org.opendatakit.services.R;
@@ -317,7 +318,9 @@ public abstract class AbsSyncBaseActivity extends AppCompatActivity
       builder.setMessage(message);
       builder.setNeutralButton(android.R.string.ok, new DialogInterface.OnClickListener() {
          public void onClick(DialogInterface dialog, int id) {
-//            activity.finish();
+             if (activity.getClass().getSimpleName().equals("VerifyServerSettingsActivity")) {
+                activity.finish();
+            }
             dialog.dismiss();
          }
       });

--- a/services_app/src/main/java/org/opendatakit/services/sync/actions/activities/AbsSyncBaseActivity.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/actions/activities/AbsSyncBaseActivity.java
@@ -318,8 +318,8 @@ public abstract class AbsSyncBaseActivity extends AppCompatActivity
       builder.setMessage(message);
       builder.setNeutralButton(android.R.string.ok, new DialogInterface.OnClickListener() {
          public void onClick(DialogInterface dialog, int id) {
-             if (activity.getClass().getSimpleName().equals("VerifyServerSettingsActivity")) {
-                activity.finish();
+            if (activity instanceof VerifyServerSettingsActivity){
+               activity.finish();
             }
             dialog.dismiss();
          }


### PR DESCRIPTION

The "Change user/Logout" screen (in which the changes needs to be made) corresponds to the _LoginFragment_ in the code. This fragment extends _AbsSyncUIFragment_, which uses the _showAuthenticationErrorDialog_ function of the _AbsSyncBaseActivity_ to display 2 error dialogs.
<img width="927" alt="2" src="https://user-images.githubusercontent.com/43718257/138547387-ed5974fe-b437-4733-b910-16f807b17787.png">

The _showAuthenticationErrorDialog_ function is reused to make separate dialogs on the "Change user/Logout" screen for 2 different cases.
Case 1: Username authentication was selected but a username and password are not configured.
Case 2: No authentication type has been selected.
<img width="769" alt="3" src="https://user-images.githubusercontent.com/43718257/138546934-cbfcc307-0175-4ecf-921b-a55868866c74.png">

Fixing the function such that on clicking the "OK" button of the dialog, the user is kept on the same screen instead of being navigated to the main screen, can be applied to both these dialogs. Thereby resolving the issue. This is achieved simply by commenting out the line `activity.finish();` inside the _showAuthenticationErrorDialog_ function.
<img width="757" alt="1" src="https://user-images.githubusercontent.com/43718257/138546940-08c16e10-fde3-494a-a303-3ab4ae679d9e.png">




