### PR TITLE
Lockout

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
@@ -1086,7 +1086,7 @@ class ProcessManifestContentAndFileChanges {
    * @return
    * @throws ServicesAvailabilityException
    */
-  private String getManifestSyncETag(String tableId) throws ServicesAvailabilityException {
+  public String getManifestSyncETag(String tableId) throws ServicesAvailabilityException {
 
     URI fileManifestUri;
 


### PR DESCRIPTION
These changes lock out a device with table schema ETags that don't match the server.  Also, code was added to initialize all the apps when appropriate.   