### PR TITLE
Syncing or Download Reduced Size Images

### DIFF
--- a/services_app/src/androidTest/java/org/opendatakit/services/sync/service/logic/AggregateSynchronizerTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/sync/service/logic/AggregateSynchronizerTest.java
@@ -1375,7 +1375,7 @@ public class AggregateSynchronizerTest {
      synchronizer.uploadInstanceFile(destFile2, cat2.instanceFileDownloadUri);
 
       synchronizer.downloadInstanceFileBatch(listOfCats, testTableRes.getInstanceFilesUri(),
-          rowId, testTableId);
+          rowId, testTableId, false);
 
       synchronizer.deleteTable(testTableRes);
 

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/AggregateSynchronizer.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/AggregateSynchronizer.java
@@ -715,7 +715,7 @@ public class AggregateSynchronizer implements HttpSynchronizer {
       String tableId, String instanceId, SyncAttachmentState attachmentState,
       String lastKnownLocalRowLevelManifestETag)
       throws HttpClientWebException, IOException {
-    //android.os.Debug.waitForDebugger();
+    //android.os.Debug.waitForDebugger(); TODO
 
     URI instanceFileManifestUri =
         wrapper.constructInstanceFileManifestUri(serverInstanceFileUri, instanceId);

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/AggregateSynchronizer.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/AggregateSynchronizer.java
@@ -715,7 +715,7 @@ public class AggregateSynchronizer implements HttpSynchronizer {
       String tableId, String instanceId, SyncAttachmentState attachmentState,
       String lastKnownLocalRowLevelManifestETag)
       throws HttpClientWebException, IOException {
-    android.os.Debug.waitForDebugger();
+    //android.os.Debug.waitForDebugger();
 
     URI instanceFileManifestUri =
         wrapper.constructInstanceFileManifestUri(serverInstanceFileUri, instanceId);

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/AggregateSynchronizer.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/AggregateSynchronizer.java
@@ -715,6 +715,7 @@ public class AggregateSynchronizer implements HttpSynchronizer {
       String tableId, String instanceId, SyncAttachmentState attachmentState,
       String lastKnownLocalRowLevelManifestETag)
       throws HttpClientWebException, IOException {
+    android.os.Debug.waitForDebugger();
 
     URI instanceFileManifestUri =
         wrapper.constructInstanceFileManifestUri(serverInstanceFileUri, instanceId);
@@ -1052,7 +1053,7 @@ public class AggregateSynchronizer implements HttpSynchronizer {
 
   @Override
   public void downloadInstanceFileBatch(List<CommonFileAttachmentTerms> filesToDownload,
-      String serverInstanceFileUri, String instanceId, String tableId) throws HttpClientWebException, IOException {
+      String serverInstanceFileUri, String instanceId, String tableId, boolean reduceImageSize) throws HttpClientWebException, IOException {
     // boolean downloadedAllFiles = true;
 
     URI instanceFilesDownloadUri = wrapper.constructInstanceFileBulkDownloadUri(serverInstanceFileUri, instanceId);

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/AggregateSynchronizer.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/AggregateSynchronizer.java
@@ -1062,6 +1062,7 @@ public class AggregateSynchronizer implements HttpSynchronizer {
     for (CommonFileAttachmentTerms cat : filesToDownload) {
       OdkTablesFileManifestEntry entry = new OdkTablesFileManifestEntry();
       entry.filename = cat.rowPathUri;
+      entry.reduceImage = String.valueOf(reduceImageSize);
       entries.add(entry);
     }
 

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/AidlSynchronizer.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/AidlSynchronizer.java
@@ -337,9 +337,9 @@ class AidlSynchronizer implements Synchronizer {
   }
 
   @Override
-  public void downloadInstanceFileBatch(List<CommonFileAttachmentTerms> filesToDownload, String serverInstanceFileUri, String instanceId, String tableId) throws HttpClientWebException {
+  public void downloadInstanceFileBatch(List<CommonFileAttachmentTerms> filesToDownload, String serverInstanceFileUri, String instanceId, String tableId, boolean reduceImageSize) throws HttpClientWebException {
     try {
-      getRemoteInterface().downloadInstanceFileBatch(filesToDownload, serverInstanceFileUri, instanceId, tableId);
+      getRemoteInterface().downloadInstanceFileBatch(filesToDownload, serverInstanceFileUri, instanceId, tableId, reduceImageSize);
     } catch (RemoteException e) {
       rethrowException(e);
     }

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/HttpSynchronizer.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/HttpSynchronizer.java
@@ -368,7 +368,7 @@ public interface HttpSynchronizer extends Synchronizer {
    */
   @Override
   void downloadInstanceFileBatch(List<CommonFileAttachmentTerms> filesToDownload,
-                                 String serverInstanceFileUri, String instanceId, String tableId)
+                                 String serverInstanceFileUri, String instanceId, String tableId, boolean reduceImageSize)
       throws HttpClientWebException, IOException;
 
   /**

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
@@ -703,7 +703,7 @@ class ProcessManifestContentAndFileChanges {
    * the server. Based upon that and the attachmentState actions, it determines
    * whether the row can be transitioned into the synced state (from synced_pending_files).
    *
-   * @param serverInstanceFileUri
+   * @param serverInstanceFileUri does not identify a file on a server
    * @param tableId
    * @param localRow
    * @param attachmentState
@@ -717,8 +717,8 @@ class ProcessManifestContentAndFileChanges {
       ArrayList<ColumnDefinition> fileAttachmentColumns,
       SyncAttachmentState attachmentState) throws HttpClientWebException,
       IOException, ServicesAvailabilityException  {
-
-
+    android.os.Debug.waitForDebugger();
+  //TODO (omkar) attachmentState always either synced_pending_files or none?
     // list of local non-null uriFragment field values
     ArrayList<String> uriFragments = new ArrayList<String>();
 
@@ -815,8 +815,12 @@ class ProcessManifestContentAndFileChanges {
           if (cat.localFile.exists()) {
             // Check if the server and local versions match
             String localMd5 = ODKFileUtils.getMd5Hash(sc.getAppName(), cat.localFile);
-
-            if (!localMd5.equals(entry.md5hash)) {
+            if (attachmentState == SyncAttachmentState.REDUCED_DOWNLOAD
+              || attachmentState == SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD) {
+              if (!(localMd5.equals(entry.md5hash) || localMd5.equals(entry.reducedImageMd5Hash))) {
+                filesToDownloadSizes.put(cat, entry.contentLength);
+              }
+            } else if (!localMd5.equals(entry.md5hash)) {
               // Found, but it is wrong locally, so we need to pull it
               log.e(LOGTAG, "syncRowLevelFileAttachments Row-level Manifest: md5Hash on server does not match local file hash!");
               filesToDownloadSizes.put(cat, entry.contentLength);
@@ -906,7 +910,8 @@ class ProcessManifestContentAndFileChanges {
         attachmentState.equals(SyncAttachmentState.DOWNLOAD)) {
       long batchSize = 0;
       List<CommonFileAttachmentTerms> batch = new LinkedList<CommonFileAttachmentTerms>();
-
+      boolean reduceImageSize = attachmentState == SyncAttachmentState.REDUCED_DOWNLOAD ||
+              attachmentState == SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD;
       for (CommonFileAttachmentTerms fileAttachment : filesToDownloadSizes.keySet()) {
 
         // Check if adding the file exceeds the batch limit. If so, download the current batch
@@ -917,7 +922,7 @@ class ProcessManifestContentAndFileChanges {
             !batch.isEmpty()) {
           log.i(LOGTAG, "syncRowLevelFileAttachments downloading batch for " + instanceId);
           sc.getSynchronizer().downloadInstanceFileBatch(batch,
-              serverInstanceFileUri, instanceId, tableId);
+              serverInstanceFileUri, instanceId, tableId, reduceImageSize);
           batch.clear();
           batchSize = 0;
         }
@@ -930,14 +935,14 @@ class ProcessManifestContentAndFileChanges {
         // download the final batch
         log.i(LOGTAG, "syncRowLevelFileAttachments downloading batch for " + instanceId);
         sc.getSynchronizer().downloadInstanceFileBatch(batch, serverInstanceFileUri,
-            instanceId, tableId);
+            instanceId, tableId, reduceImageSize);
       }
 
       fullySyncedDownloads = !impossibleToFullySyncDownloadsServerMissingFileToDownload;
     }
 
     if ( attachmentState == SyncAttachmentState.NONE ||
-        ((fullySyncedUploads || (attachmentState == SyncAttachmentState.DOWNLOAD)) &&
+        ((fullySyncedUploads || (attachmentState == SyncAttachmentState.DOWNLOAD || attachmentState == SyncAttachmentState.REDUCED_DOWNLOAD)) &&
             (fullySyncedDownloads || (attachmentState == SyncAttachmentState.UPLOAD))) ) {
       // there may be synced_pending_files rows, but all of the uploads we want to do
       // have been uploaded, and all of the downloads we want to do have been downloaded.

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
@@ -797,7 +797,6 @@ class ProcessManifestContentAndFileChanges {
         // remove from the list -- anything left over is orphaned or needs to be
         // pushed up to the server because the server doesn't know about it.
         uriFragments.remove(entry.filename);
-
         CommonFileAttachmentTerms cat = sc.getSynchronizer().createCommonFileAttachmentTerms(
             serverInstanceFileUri, tableId, instanceId, entry.filename);
 

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
@@ -871,6 +871,7 @@ class ProcessManifestContentAndFileChanges {
       log.i(LOGTAG, "syncRowLevelFileAttachments no files to send to server -- they are all synced");
       fullySyncedUploads = true;
     } else if (attachmentState.equals(SyncAttachmentState.SYNC) ||
+        attachmentState.equals(SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD) ||
         attachmentState.equals(SyncAttachmentState.UPLOAD)) {
       long batchSize = 0;
       List<CommonFileAttachmentTerms> batch = new LinkedList<CommonFileAttachmentTerms>();
@@ -906,6 +907,7 @@ class ProcessManifestContentAndFileChanges {
       log.i(LOGTAG, "syncRowLevelFileAttachments no files to fetch from server -- they are all synced");
       fullySyncedDownloads = !impossibleToFullySyncDownloadsServerMissingFileToDownload;
     } else if (attachmentState.equals(SyncAttachmentState.SYNC) ||
+        attachmentState.equals(SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD) ||
         attachmentState.equals(SyncAttachmentState.DOWNLOAD)) {
       long batchSize = 0;
       List<CommonFileAttachmentTerms> batch = new LinkedList<CommonFileAttachmentTerms>();
@@ -963,7 +965,7 @@ class ProcessManifestContentAndFileChanges {
       }
     }
 
-    if ( fullySyncedUploads && fullySyncedDownloads ) {
+    if ( fullySyncedUploads && fullySyncedDownloads && attachmentState != SyncAttachmentState.REDUCED_DOWNLOAD && attachmentState != SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD ) {
       log.i(LOGTAG, "syncRowLevelFileAttachments SUCCESS syncing file attachments for " + instanceId);
       return true;
     } else {

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
@@ -904,6 +904,7 @@ class ProcessManifestContentAndFileChanges {
       fullySyncedUploads = true;
     }
     // 5) Download the files from the server
+    boolean atleast1Download = false;
     if (filesToDownloadSizes.isEmpty()){
       log.i(LOGTAG, "syncRowLevelFileAttachments no files to fetch from server -- they are all synced");
       fullySyncedDownloads = !impossibleToFullySyncDownloadsServerMissingFileToDownload;
@@ -911,6 +912,7 @@ class ProcessManifestContentAndFileChanges {
         attachmentState.equals(SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD) ||
         attachmentState.equals(SyncAttachmentState.DOWNLOAD) ||
         attachmentState.equals(SyncAttachmentState.REDUCED_DOWNLOAD)) {
+      atleast1Download = true;
       long batchSize = 0;
       List<CommonFileAttachmentTerms> batch = new LinkedList<CommonFileAttachmentTerms>();
 
@@ -970,7 +972,7 @@ class ProcessManifestContentAndFileChanges {
 
     if ( fullySyncedUploads && fullySyncedDownloads ) {
       log.i(LOGTAG, "syncRowLevelFileAttachments SUCCESS syncing file attachments for " + instanceId);
-      if ( attachmentState == SyncAttachmentState.REDUCED_DOWNLOAD || attachmentState == SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD ) {
+      if ( attachmentState == SyncAttachmentState.REDUCED_DOWNLOAD || attachmentState == SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD && atleast1Download ) {
         log.i(LOGTAG, "syncRowLevelFileAttachments Involved reduced download, returned false");
         return false;
       }

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
@@ -703,7 +703,7 @@ class ProcessManifestContentAndFileChanges {
    * the server. Based upon that and the attachmentState actions, it determines
    * whether the row can be transitioned into the synced state (from synced_pending_files).
    *
-   * @param serverInstanceFileUri does not identify a file on a server
+   * @param serverInstanceFileUri Note that this does not identify a file on a server
    * @param tableId
    * @param localRow
    * @param attachmentState
@@ -717,8 +717,7 @@ class ProcessManifestContentAndFileChanges {
       ArrayList<ColumnDefinition> fileAttachmentColumns,
       SyncAttachmentState attachmentState) throws HttpClientWebException,
       IOException, ServicesAvailabilityException  {
-    android.os.Debug.waitForDebugger();
-  //TODO (omkar) attachmentState always either synced_pending_files or none?
+    android.os.Debug.waitForDebugger(); //TODO
     // list of local non-null uriFragment field values
     ArrayList<String> uriFragments = new ArrayList<String>();
 
@@ -797,6 +796,7 @@ class ProcessManifestContentAndFileChanges {
         // remove from the list -- anything left over is orphaned or needs to be
         // pushed up to the server because the server doesn't know about it.
         uriFragments.remove(entry.filename);
+
         CommonFileAttachmentTerms cat = sc.getSynchronizer().createCommonFileAttachmentTerms(
             serverInstanceFileUri, tableId, instanceId, entry.filename);
 
@@ -814,6 +814,7 @@ class ProcessManifestContentAndFileChanges {
           if (cat.localFile.exists()) {
             // Check if the server and local versions match
             String localMd5 = ODKFileUtils.getMd5Hash(sc.getAppName(), cat.localFile);
+
             if (attachmentState == SyncAttachmentState.REDUCED_DOWNLOAD
               || attachmentState == SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD) {
               if (!(localMd5.equals(entry.md5hash) || localMd5.equals(entry.reducedImageMd5Hash))) {
@@ -911,6 +912,7 @@ class ProcessManifestContentAndFileChanges {
         attachmentState.equals(SyncAttachmentState.DOWNLOAD)) {
       long batchSize = 0;
       List<CommonFileAttachmentTerms> batch = new LinkedList<CommonFileAttachmentTerms>();
+
       boolean reduceImageSize = attachmentState == SyncAttachmentState.REDUCED_DOWNLOAD ||
               attachmentState == SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD;
       for (CommonFileAttachmentTerms fileAttachment : filesToDownloadSizes.keySet()) {
@@ -965,9 +967,9 @@ class ProcessManifestContentAndFileChanges {
       }
     }
 
-    if (fullySyncedUploads && fullySyncedDownloads) {
+    if ( fullySyncedUploads && fullySyncedDownloads ) {
       log.i(LOGTAG, "syncRowLevelFileAttachments SUCCESS syncing file attachments for " + instanceId);
-      if (attachmentState == SyncAttachmentState.REDUCED_DOWNLOAD || attachmentState == SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD) {
+      if ( attachmentState == SyncAttachmentState.REDUCED_DOWNLOAD || attachmentState == SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD ) {
         log.i(LOGTAG, "syncRowLevelFileAttachments Involved reduced download, returned false");
         return false;
       }

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
@@ -965,8 +965,12 @@ class ProcessManifestContentAndFileChanges {
       }
     }
 
-    if ( fullySyncedUploads && fullySyncedDownloads && attachmentState != SyncAttachmentState.REDUCED_DOWNLOAD && attachmentState != SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD ) {
+    if (fullySyncedUploads && fullySyncedDownloads) {
       log.i(LOGTAG, "syncRowLevelFileAttachments SUCCESS syncing file attachments for " + instanceId);
+      if (attachmentState == SyncAttachmentState.REDUCED_DOWNLOAD || attachmentState == SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD) {
+        log.i(LOGTAG, "syncRowLevelFileAttachments Involved reduced download, returned false");
+        return false;
+      }
       return true;
     } else {
       // we are fully sync'd if we were able to fully sync both the uploads and the downloads

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessManifestContentAndFileChanges.java
@@ -717,7 +717,7 @@ class ProcessManifestContentAndFileChanges {
       ArrayList<ColumnDefinition> fileAttachmentColumns,
       SyncAttachmentState attachmentState) throws HttpClientWebException,
       IOException, ServicesAvailabilityException  {
-    android.os.Debug.waitForDebugger(); //TODO
+    //android.os.Debug.waitForDebugger(); //TODO
     // list of local non-null uriFragment field values
     ArrayList<String> uriFragments = new ArrayList<String>();
 
@@ -909,7 +909,8 @@ class ProcessManifestContentAndFileChanges {
       fullySyncedDownloads = !impossibleToFullySyncDownloadsServerMissingFileToDownload;
     } else if (attachmentState.equals(SyncAttachmentState.SYNC) ||
         attachmentState.equals(SyncAttachmentState.SYNC_WITH_REDUCED_DOWNLOAD) ||
-        attachmentState.equals(SyncAttachmentState.DOWNLOAD)) {
+        attachmentState.equals(SyncAttachmentState.DOWNLOAD) ||
+        attachmentState.equals(SyncAttachmentState.REDUCED_DOWNLOAD)) {
       long batchSize = 0;
       List<CommonFileAttachmentTerms> batch = new LinkedList<CommonFileAttachmentTerms>();
 

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessRowDataPullServerUpdates.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessRowDataPullServerUpdates.java
@@ -98,7 +98,7 @@ class ProcessRowDataPullServerUpdates extends ProcessRowDataSharedBase {
       RowResourceList rows) throws IOException, ServicesAvailabilityException {
     String tableId = tableResource.getTableId();
     TableLevelResult tableLevelResult = sc.getTableLevelResult(tableId);
-
+    //android.os.Debug.waitForDebugger();
     if (rows.getRows().isEmpty()) {
       // nothing here -- let caller determine whether we are done or
       // whether we need to issue another request to the server.

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessRowDataPullServerUpdates.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessRowDataPullServerUpdates.java
@@ -98,7 +98,7 @@ class ProcessRowDataPullServerUpdates extends ProcessRowDataSharedBase {
       RowResourceList rows) throws IOException, ServicesAvailabilityException {
     String tableId = tableResource.getTableId();
     TableLevelResult tableLevelResult = sc.getTableLevelResult(tableId);
-    //android.os.Debug.waitForDebugger();
+    //android.os.Debug.waitForDebugger(); TODO
     if (rows.getRows().isEmpty()) {
       // nothing here -- let caller determine whether we are done or
       // whether we need to issue another request to the server.

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessRowDataSyncAttachments.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessRowDataSyncAttachments.java
@@ -88,7 +88,7 @@ class ProcessRowDataSyncAttachments extends ProcessRowDataSharedBase {
       TableDefinitionEntry te, OrderedColumns orderedColumns,
       ArrayList<ColumnDefinition> fileAttachmentColumns,
       SyncAttachmentState attachmentState) throws ServicesAvailabilityException {
-
+    //android.os.Debug.waitForDebugger();
     // Prepare the tableLevelResult.
     String tableId = te.getTableId();
     TableLevelResult tableLevelResult = sc.getTableLevelResult(tableId);

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessRowDataSyncAttachments.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessRowDataSyncAttachments.java
@@ -88,7 +88,8 @@ class ProcessRowDataSyncAttachments extends ProcessRowDataSharedBase {
       TableDefinitionEntry te, OrderedColumns orderedColumns,
       ArrayList<ColumnDefinition> fileAttachmentColumns,
       SyncAttachmentState attachmentState) throws ServicesAvailabilityException {
-    //android.os.Debug.waitForDebugger();
+
+    //android.os.Debug.waitForDebugger(); TODO
     // Prepare the tableLevelResult.
     String tableId = te.getTableId();
     TableLevelResult tableLevelResult = sc.getTableLevelResult(tableId);
@@ -110,6 +111,9 @@ class ProcessRowDataSyncAttachments extends ProcessRowDataSharedBase {
       DbHandle db = null;
       try {
         db = sc.getDatabase();
+
+
+
 
         // We need to create a temporary table and fill it with all the IDs of
         // the rows that may have attachments that should be sync'd to the server.

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessRowDataSyncAttachments.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/ProcessRowDataSyncAttachments.java
@@ -111,9 +111,6 @@ class ProcessRowDataSyncAttachments extends ProcessRowDataSharedBase {
       try {
         db = sc.getDatabase();
 
-
-
-
         // We need to create a temporary table and fill it with all the IDs of
         // the rows that may have attachments that should be sync'd to the server.
         //
@@ -300,10 +297,16 @@ class ProcessRowDataSyncAttachments extends ProcessRowDataSharedBase {
               case SYNC:
                 idString = R.string.sync_syncing_attachments_server_row;
                 break;
+              case SYNC_WITH_REDUCED_DOWNLOAD:
+                idString = R.string.sync_syncing_attachments_server_row;
+                break;
               case UPLOAD:
                 idString = R.string.sync_uploading_attachments_server_row;
                 break;
               case DOWNLOAD:
+                idString = R.string.sync_downloading_attachments_server_row;
+                break;
+              case REDUCED_DOWNLOAD:
                 idString = R.string.sync_downloading_attachments_server_row;
                 break;
               }

--- a/services_app/src/main/java/org/opendatakit/services/sync/service/logic/Synchronizer.java
+++ b/services_app/src/main/java/org/opendatakit/services/sync/service/logic/Synchronizer.java
@@ -389,7 +389,7 @@ public interface Synchronizer {
    * @throws IOException
    */
   void downloadInstanceFileBatch(List<CommonFileAttachmentTerms> filesToDownload,
-                                 String serverInstanceFileUri, String instanceId, String tableId)
+                                 String serverInstanceFileUri, String instanceId, String tableId, boolean reduceImageSize)
       throws HttpClientWebException, IOException;
 
   /**

--- a/services_app/src/main/res/values-es/arrays.xml
+++ b/services_app/src/main/res/values-es/arrays.xml
@@ -15,11 +15,15 @@
         <item>UPLOAD</item>
         <item>DOWNLOAD</item>
         <item>NONE</item>
+        <item>REDUCED_DOWNLOAD</item>
+        <item>SYNC_WITH_REDUCED_DOWNLOAD</item>
     </string-array>
     <string-array name="sync_attachment_option_names">
         <item>Sincronizar Todos</item>
         <item>Solo enviar archivos (imágenes, audio, video) al servidor</item>
         <item>Solo recibir archivos (imágenes, audio, video) del servidor</item>
         <item>No sincronizar archivos</item>
+        <item>Solo recibir archivos (imágenes, audio, video) del servidor, con los imagenes mas pequeno de normal</item>
+        <item>Sincronizar Todos, pero recibir imagenes mas pequeno de normal</item>
     </string-array>
 </resources>

--- a/services_app/src/main/res/values/arrays.xml
+++ b/services_app/src/main/res/values/arrays.xml
@@ -23,7 +23,7 @@
         <item>Upload Attachments Only</item>
         <item>Download Attachments Only</item>
         <item>Do Not Sync Attachments</item>
-        <item>Download All Attachments Only, Reducing Size of Images Before Download</item>
-        <item>Fully Sync Attachments, Reducing Size of Images Before Download</item>
+        <item>Download Attachments Only, Imgs Reduced Size</item>
+        <item>Fully Sync Attachments, Download Reduced Imgs</item>
     </string-array>
 </resources>

--- a/services_app/src/main/res/values/arrays.xml
+++ b/services_app/src/main/res/values/arrays.xml
@@ -15,11 +15,15 @@
         <item>UPLOAD</item>
         <item>DOWNLOAD</item>
         <item>NONE</item>
+        <item>REDUCED_DOWNLOAD</item>
+        <item>SYNC_WITH_REDUCED_DOWNLOAD</item>
     </string-array>
     <string-array name="sync_attachment_option_names">
         <item>Fully Sync Attachments</item>
         <item>Upload Attachments Only</item>
         <item>Download Attachments Only</item>
         <item>Do Not Sync Attachments</item>
+        <item>Download All Attachments Only, Reducing Size of Images Before Download</item>
+        <item>Fully Sync Attachments, Reducing Size of Images Before Download</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Allows functionality to do a full sync while downloading reduced size images, or just downloading all attachments while getting the images reduced size.

Involves:
-UI modification
-logic for determining whether an image is reduced size and we want to overwrite that with a full size image.

@wbrunette 