### PR TITLE
Update android tests

### DIFF
--- a/services_app/build.gradle
+++ b/services_app/build.gradle
@@ -116,7 +116,7 @@ allprojects {
 
 dependencies {
     implementation fileTree(include: '*.jar', dir: 'libs')
-    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation 'androidx.annotation:annotation:1.3.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.preference:preference:1.1.1'
@@ -129,6 +129,7 @@ dependencies {
 
     implementation group: 'com.google.zxing', name: 'core', version: '3.3.0'
     implementation group: 'com.journeyapps', name: 'zxing-android-embedded', version: '3.5.0'
+    implementation 'androidx.test:core:1.4.0'
 
     if (libraryProjectPath.exists() && gradle.useLocal) { // Local project is favoured
         implementation project(libraryProjectName)
@@ -145,10 +146,10 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation fileTree(include: '*.jar', dir: 'libs')
-    androidTestImplementation 'androidx.annotation:annotation:1.2.0'
+    androidTestImplementation 'androidx.annotation:annotation:1.3.0'
 
-    testImplementation 'junit:junit:4.13.1'
-    testImplementation 'androidx.annotation:annotation:1.2.0'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'androidx.annotation:annotation:1.3.0'
 }
 
 task grantPermissionForODKApp {

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/ODKServiceTestRule.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/ODKServiceTestRule.java
@@ -28,7 +28,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
 import androidx.annotation.NonNull;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.internal.util.Checks;
 import android.util.Log;
 import org.junit.rules.TestRule;
@@ -69,7 +69,7 @@ public class ODKServiceTestRule implements TestRule {
    private ODKServiceTestRule(long timeout, TimeUnit timeUnit) {
       mTimeout = timeout;
       mTimeUnit = timeUnit;
-      mAttemptToBindConnections = new LinkedBlockingQueue<ProxyServiceConnection>();
+      mAttemptToBindConnections = new LinkedBlockingQueue<>();
    }
 
 
@@ -188,7 +188,7 @@ public class ODKServiceTestRule implements TestRule {
 
       for(int i=0; i < MAX_CONNECTION_ATTEMPTS; i++) {
 
-         boolean isBound = InstrumentationRegistry.getContext().bindService(intent, servConn, flags);
+         boolean isBound = InstrumentationRegistry.getInstrumentation().getContext().bindService(intent, servConn, flags);
 
          // block until service connection is established
          if (isBound) {
@@ -225,7 +225,7 @@ public class ODKServiceTestRule implements TestRule {
     * reliable way to guarantee successful disconnect without access to service lifecycle.
     */
    // Visible for testing
-   void shutdownService() throws TimeoutException {
+   void shutdownService() {
       Log.e(TAG, "READY TO UNBIND");
       while (!mAttemptToBindConnections.isEmpty()) {
          ProxyServiceConnection conn = null;
@@ -234,8 +234,9 @@ public class ODKServiceTestRule implements TestRule {
          } catch (InterruptedException e) {
             e.printStackTrace();
          }
-         if(!conn.binderIsNull()) {
-            InstrumentationRegistry.getContext().unbindService(conn);
+          assert conn != null;
+          if(!conn.binderIsNull()) {
+             InstrumentationRegistry.getInstrumentation().getContext().unbindService(conn);
             Log.e(TAG, "CALLED UNBIND");
          }
       }

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/ODKServiceTestRule.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/ODKServiceTestRule.java
@@ -28,7 +28,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
 import androidx.annotation.NonNull;
-import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.internal.util.Checks;
 import android.util.Log;
 import org.junit.rules.TestRule;
@@ -188,7 +188,7 @@ public class ODKServiceTestRule implements TestRule {
 
       for(int i=0; i < MAX_CONNECTION_ATTEMPTS; i++) {
 
-         boolean isBound = InstrumentationRegistry.getInstrumentation().getContext().bindService(intent, servConn, flags);
+         boolean isBound = ApplicationProvider.getApplicationContext().bindService(intent, servConn, flags);
 
          // block until service connection is established
          if (isBound) {
@@ -236,7 +236,7 @@ public class ODKServiceTestRule implements TestRule {
          }
           assert conn != null;
           if(!conn.binderIsNull()) {
-             InstrumentationRegistry.getInstrumentation().getContext().unbindService(conn);
+             ApplicationProvider.getApplicationContext().unbindService(conn);
             Log.e(TAG, "CALLED UNBIND");
          }
       }

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseTestAbstractBase.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseTestAbstractBase.java
@@ -1,14 +1,20 @@
 package org.opendatakit.database.service;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
+import android.util.Log;
+
 import androidx.annotation.Nullable;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.rule.ServiceTestRule;
-import android.util.Log;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -19,9 +25,6 @@ import org.opendatakit.services.database.AndroidConnectFactory;
 
 import java.util.List;
 import java.util.concurrent.TimeoutException;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Created by wrb on 9/26/2017.
@@ -63,6 +66,7 @@ abstract class OdkDatabaseTestAbstractBase {
       tearDownBefore();
       UserDbInterface serviceInterface = bindToDbService();
       try {
+          assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("OdkDatabaseServiceTest", "tearDown: " + db.getDatabaseHandle());
          verifyNoTablesExistNCleanAllTables(serviceInterface, db);
@@ -74,7 +78,7 @@ abstract class OdkDatabaseTestAbstractBase {
    }
 
    @Nullable protected UserDbInterfaceImpl bindToDbService() {
-      Context context = InstrumentationRegistry.getContext();
+      Context context = ApplicationProvider.getApplicationContext();
 
       ++bindToDbServiceCount;
       Intent bind_intent = new Intent();

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseTypesTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseTypesTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -59,7 +60,7 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
    private static final String TEST_STR_i = "TestBoolStr";
    private static final String TEST_ARRAY_i = "[\"Test1\",\"Test2\"]";
 
-   private static final ArrayList<String> TEST_ARRAY_i_CHECK = new ArrayList<String>();
+   private static final ArrayList<String> TEST_ARRAY_i_CHECK = new ArrayList<>();
 
    static {
       TEST_ARRAY_i_CHECK.addAll(Arrays.asList("Test1", "Test2"));
@@ -74,7 +75,7 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
    }
 
    @NonNull private List<Column> createColumnList() {
-      List<Column> columns = new ArrayList<Column>();
+      List<Column> columns = new ArrayList<>();
 
       columns
           .add(new Column(COL_INTEGER_ID, "column Integer", ElementDataType.integer.name(), null));
@@ -136,34 +137,34 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
    }
 
    private void verifyRowTestSet1(TypedRow row) {
-      assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(TEST_INT_1));
+      assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) TEST_INT_1);
       assertNull(row.getDataByKey(COL_NUMBER_ID));
-      assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.valueOf(TEST_BOOL_1));
+      assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.TRUE);
       assertNull(row.getDataByKey(COL_ROWPATH_ID));
       assertNull(row.getDataByKey(COL_CONFIGPATH_ID));
       assertNull(row.getDataByKey(COL_ARRAY_ID));
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
 
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ACC), Double.valueOf(TEST_NUM_1));
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ALT), Double.valueOf(TEST_NUM_1));
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LAT), Double.valueOf(TEST_NUM_1));
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LONG), Double.valueOf(TEST_NUM_1));
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ACC), TEST_NUM_1);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ALT), TEST_NUM_1);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LAT), TEST_NUM_1);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LONG), TEST_NUM_1);
 
    }
 
    private void verifyRowTestSeti(TypedRow row, int i) {
-      assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(TEST_INT_i + i));
-      assertEquals(row.getDataByKey(COL_NUMBER_ID), Double.valueOf(TEST_NUM_i + i));
-      assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.valueOf((i % 2 != 0)));
+      assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) (TEST_INT_i + i));
+      assertEquals(row.getDataByKey(COL_NUMBER_ID), TEST_NUM_i + i);
+      assertEquals(row.getDataByKey(COL_BOOL_ID), (i % 2 != 0));
       assertEquals(row.getDataByKey(COL_ROWPATH_ID), TEST_ROWPATH_i + i);
       assertEquals(row.getDataByKey(COL_CONFIGPATH_ID), TEST_CONFIGPATH_i + i);
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_i + i);
 
       assertEquals(row.getDataByKey(COL_ARRAY_ID), TEST_ARRAY_i_CHECK);
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ACC), Double.valueOf(TEST_NUM_i + i));
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ALT), Double.valueOf(TEST_NUM_i + i));
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LAT), Double.valueOf(TEST_NUM_i + i));
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LONG), Double.valueOf(TEST_NUM_i + i));
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ACC), TEST_NUM_i + i);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ALT), TEST_NUM_i + i);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LAT), TEST_NUM_i + i);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LONG), TEST_NUM_i + i);
    }
 
    @Test public void testDbInsertSingleRowIntoTable() throws ActionNotAuthorizedException {
@@ -174,7 +175,8 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbInsertSingleRowIntoTable: " + db.getDatabaseHandle());
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, colList);
 
@@ -227,7 +229,8 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          db = serviceInterface.openDatabase(APPNAME);
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, colList);
 
          OrderedColumns columns = new OrderedColumns(APPNAME, DB_TABLE_ID, columnList);
@@ -292,6 +295,7 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+         assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase",
              "testDbInsertCheckpointRowWithBooleanIntoTable: " + db.getDatabaseHandle());
@@ -334,7 +338,8 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
          OrderedColumns columns = new OrderedColumns(APPNAME, DB_TABLE_ID, columnList);
-         db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase",
              "testDbInsertCheckpointRowWithBooleanIntoTable: " + db.getDatabaseHandle());
 
@@ -364,7 +369,7 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
             TypedRow row = new TypedRow(table.getRowAtIndex(0), columns);
             Object value = row.getDataByKey("Total");
             if (value instanceof String) {
-               int count = Integer.valueOf((String) value);
+               int count = Integer.parseInt((String) value);
                assertEquals(numRows, count);
             } else {
                fail("Should have returned a string because type of column was unknown");

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/SyncETagsUtilsTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/SyncETagsUtilsTest.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,7 +45,8 @@ public class SyncETagsUtilsTest extends OdkDatabaseTestAbstractBase {
    protected void setUpBefore() {
       try {
          serviceInterface = bindToDbService();
-         dbHandle = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          dbHandle = serviceInterface.openDatabase(APPNAME);
 
       } catch (Exception e) {
          e.printStackTrace();
@@ -380,7 +382,7 @@ public class SyncETagsUtilsTest extends OdkDatabaseTestAbstractBase {
 
    private void expectGone(String id, boolean isManifest) throws ServicesAvailabilityException {
       UserTable c = get(id, isManifest);
-      assertTrue(c.getNumberOfRows() == 0);
+       assertEquals(0, c.getNumberOfRows());
    }
 
    private void expectPresent(String id, boolean isManifest) throws ServicesAvailabilityException {

--- a/services_app/src/androidTest/java/org/opendatakit/utilities/AbstractPermissionsTestCase.java
+++ b/services_app/src/androidTest/java/org/opendatakit/utilities/AbstractPermissionsTestCase.java
@@ -63,6 +63,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Permissions tests in the database.
@@ -247,7 +248,7 @@ public class AbstractPermissionsTestCase {
   protected OrderedColumns assertEmptyTestTable(String tableId, boolean isLocked,
       boolean anonymousCanCreate, String defaultAccess) {
 
-    List<Column> columns = new ArrayList<Column>();
+    List<Column> columns = new ArrayList<>();
     // arbitrary type derived from integer
     columns.add(new Column("col0", "col0", "myothertype:integer", "[]"));
     // primitive types
@@ -278,7 +279,7 @@ public class AbstractPermissionsTestCase {
 
     OrderedColumns orderedColumns;
     try {
-      List<KeyValueStoreEntry> metaData = new ArrayList<KeyValueStoreEntry>();
+      List<KeyValueStoreEntry> metaData = new ArrayList<>();
       KeyValueStoreEntry entry;
 
       entry = KeyValueStoreUtils.buildEntry( tableId,
@@ -344,29 +345,29 @@ public class AbstractPermissionsTestCase {
         SyncState.deleted.name() : SyncState.changed.name()));
 
     RowFilterScope.Access localType;
-    if ( rowId.equals(rowIdFullNull) ) {
-      localType = RowFilterScope.Access.FULL;
-      cvValues.put(DataTableColumns.DEFAULT_ACCESS, localType.name());
-      cvValues.putNull(DataTableColumns.ROW_OWNER);
-    } else if ( rowId.equals(rowIdFullCommon) ) {
-      localType = RowFilterScope.Access.FULL;
-      cvValues.put(DataTableColumns.DEFAULT_ACCESS, localType.name());
-      cvValues.put(DataTableColumns.ROW_OWNER, commonUser);
-    } else if ( rowId.equals(rowIdHiddenCommon) ) {
-      localType = RowFilterScope.Access.HIDDEN;
-      cvValues.put(DataTableColumns.DEFAULT_ACCESS, localType.name());
-      cvValues.put(DataTableColumns.ROW_OWNER, commonUser);
-    } else if ( rowId.equals(rowIdReadOnlyCommon) ) {
-      localType = RowFilterScope.Access.READ_ONLY;
-      cvValues.put(DataTableColumns.DEFAULT_ACCESS, localType.name());
-      cvValues.put(DataTableColumns.ROW_OWNER, commonUser);
-    } else if ( rowId.equals(rowIdModifyCommon) ) {
-      localType = RowFilterScope.Access.MODIFY;
-      cvValues.put(DataTableColumns.DEFAULT_ACCESS, localType.name());
-      cvValues.put(DataTableColumns.ROW_OWNER, commonUser);
-    } else {
-      throw new IllegalArgumentException("unexpected rowId value");
-    }
+      if ( rowId.equals(rowIdFullNull) ) {
+          localType = RowFilterScope.Access.FULL;
+          cvValues.put(DataTableColumns.DEFAULT_ACCESS, localType.name());
+          cvValues.putNull(DataTableColumns.ROW_OWNER);
+      } else if ( rowId.equals(rowIdFullCommon) ) {
+          localType = RowFilterScope.Access.FULL;
+          cvValues.put(DataTableColumns.DEFAULT_ACCESS, localType.name());
+          cvValues.put(DataTableColumns.ROW_OWNER, commonUser);
+      } else if ( rowId.equals(rowIdHiddenCommon) ) {
+          localType = RowFilterScope.Access.HIDDEN;
+          cvValues.put(DataTableColumns.DEFAULT_ACCESS, localType.name());
+          cvValues.put(DataTableColumns.ROW_OWNER, commonUser);
+      } else if ( rowId.equals(rowIdReadOnlyCommon) ) {
+          localType = RowFilterScope.Access.READ_ONLY;
+          cvValues.put(DataTableColumns.DEFAULT_ACCESS, localType.name());
+          cvValues.put(DataTableColumns.ROW_OWNER, commonUser);
+      } else if ( rowId.equals(rowIdModifyCommon) ) {
+          localType = RowFilterScope.Access.MODIFY;
+          cvValues.put(DataTableColumns.DEFAULT_ACCESS, localType.name());
+          cvValues.put(DataTableColumns.ROW_OWNER, commonUser);
+      } else {
+          throw new IllegalArgumentException("unexpected rowId value");
+      }
 
     cvValues.putNull(DataTableColumns.GROUP_MODIFY);
     cvValues.putNull(DataTableColumns.GROUP_READ_ONLY);
@@ -600,7 +601,7 @@ public class AbstractPermissionsTestCase {
 
   protected void assertRowInSyncStateTestTable(String tableId,
       OrderedColumns orderedColumns,
-      String rowId, SyncState state) throws ActionNotAuthorizedException {
+      String rowId, SyncState state) {
 
     ODKDatabaseImplUtils.get().privilegedDeleteRowWithId(db, tableId, rowId, adminUser);
 
@@ -680,8 +681,7 @@ public class AbstractPermissionsTestCase {
 
   protected void assertInConflictRowInSyncStateTestTable(String tableId,
       OrderedColumns orderedColumns,
-      String rowId, int localConflictType, int serverConflictType)
-      throws ActionNotAuthorizedException {
+      String rowId, int localConflictType, int serverConflictType) {
 
     ODKDatabaseImplUtils.get().privilegedDeleteRowWithId(db, tableId, rowId, adminUser);
 
@@ -1090,13 +1090,11 @@ public class AbstractPermissionsTestCase {
       // first entry should match expectation
       if ( (expectFirstRemainingType == FirstSavepointTimestampType.CHECKPOINT_NEW_ROW) &&
           !c.isNull(idxType) ) {
-        assertTrue("Expected first row to be a new-row checkpoint: " + identifyingDescription,
-            false);
+          fail("Expected first row to be a new-row checkpoint: " + identifyingDescription);
       }
       if ( (expectFirstRemainingType != FirstSavepointTimestampType.CHECKPOINT_NEW_ROW) &&
           c.isNull(idxType) ) {
-        assertTrue("Expected first row to not be a checkpoint: " + identifyingDescription,
-            false);
+          fail("Expected first row to not be a checkpoint: " + identifyingDescription);
       }
 
       if ( expectFirstRemainingType == FirstSavepointTimestampType.CHECKPOINT_NEW_ROW ||
@@ -1156,13 +1154,13 @@ public class AbstractPermissionsTestCase {
       // subsequent updates should all be checkpoints
       while ( c.moveToNext() ) {
         if ( !syncState.equals(SyncState.in_conflict.name()) && !c.isNull(idxType) ) {
-          assertTrue("Expected subsequent rows to be checkpoints: " + identifyingDescription,
-              false);
+
+
+            fail("Expected subsequent rows to be checkpoints: " + identifyingDescription);
           return false;
         }
         if ( syncState.equals(SyncState.in_conflict.name()) && c.isNull(idxType) ) {
-          assertTrue("Expected subsequent rows to not be checkpoints: " + identifyingDescription,
-              false);
+            fail("Expected subsequent rows to not be checkpoints: " + identifyingDescription);
           return false;
         }
         assertEquals("Expected subsequent rows to be " + syncState + " sync state: " +
@@ -1177,7 +1175,7 @@ public class AbstractPermissionsTestCase {
 
       return true;
     } catch (SQLiteException e) {
-      assertFalse("shouldn't get an error", true);
+        fail("shouldn't get an error");
       return false;
     } finally {
       if ( c != null && !c.isClosed() ) {
@@ -1275,7 +1273,7 @@ public class AbstractPermissionsTestCase {
       break;
     case LOCALLY_IN_CONFLICT:
       if ( baseTable.getNumberOfRows() != 2 ) {
-        assertTrue("expected 2 conflict rows -- found one", false);
+          fail("expected 2 conflict rows -- found one");
       }
       TypedRow localRow = null;
       TypedRow serverRow = null;
@@ -1404,36 +1402,36 @@ public class AbstractPermissionsTestCase {
       throw new IllegalStateException("Expected all rows to be quantified at this point");
     }
 
-    if ( isTableLocked ) {
-      if ( rowId.startsWith(rowIdFullNull) ) {
-        // not owner of row, can't change it
-        return false;
-      }
+      if ( isTableLocked ) {
+          if ( rowId.startsWith(rowIdFullNull) ) {
+              // not owner of row, can't change it
+              return false;
+          }
 
-      if ( changeServerPrivilegedMetadata && localRowDefaultAccessValue == serverRowDefaultAccessValue ) {
-        // logic will have server change the owner on matching rowDefaultAccessValues
-        // so we will no longer be the owner.
-        return false;
-      }
+          if ( changeServerPrivilegedMetadata && localRowDefaultAccessValue == serverRowDefaultAccessValue ) {
+              // logic will have server change the owner on matching rowDefaultAccessValues
+              // so we will no longer be the owner.
+              return false;
+          }
 
-      return true;
-    }
+          return true;
+      }
 
     // otherwise, we can modify the row as long as the server isn't changing anything
-    if ( !changeServerPrivilegedMetadata ) {
-      // and row type is FULL or MODIFY access
-      if ( localRowDefaultAccessValue == RowFilterScope.Access.FULL || localRowDefaultAccessValue == RowFilterScope.Access.MODIFY ) {
-        return true;
+      if ( !changeServerPrivilegedMetadata ) {
+          // and row type is FULL or MODIFY access
+          if ( localRowDefaultAccessValue == RowFilterScope.Access.FULL || localRowDefaultAccessValue == RowFilterScope.Access.MODIFY ) {
+              return true;
+          }
+          // or we are the owner
+          // TODO: perhaps more logic here if test coverage is more complete
+          if ( !rowId.startsWith(rowIdFullNull) ) {
+              // we are the owner - can change it
+              return true;
+          }
+          // otherwise the row type is hidden or read-only and we can't modify it
+          return false;
       }
-      // or we are the owner
-      // TODO: perhaps more logic here if test coverage is more complete
-      if ( !rowId.startsWith(rowIdFullNull) ) {
-        // we are the owner - can change it
-        return true;
-      }
-      // otherwise the row type is hidden or read-only and we can't modify it
-      return false;
-    }
 
     // otherwise, the server is changing the permissions.
     if ( serverRowDefaultAccessValue == RowFilterScope.Access.FULL || serverRowDefaultAccessValue == RowFilterScope.Access.MODIFY ) {
@@ -1446,12 +1444,12 @@ public class AbstractPermissionsTestCase {
       return false;
     }
 
-    if ( rowId.startsWith(rowIdFullNull) ) {
-      // we are not the owner - can't change it
-      return false;
-    }
-    // owner the same -- we can change it
-    return true;
+      if ( rowId.startsWith(rowIdFullNull) ) {
+          // we are not the owner - can't change it
+          return false;
+      }
+      // owner the same -- we can change it
+      return true;
   }
 
 
@@ -1532,12 +1530,12 @@ public class AbstractPermissionsTestCase {
       return false;
     }
 
-    if ( rowId.startsWith(rowIdFullNull) ) {
-      // we are not the owner - can't change it
-      return false;
-    }
-    // owner the same -- we can change it
-    return true;
+      if ( rowId.startsWith(rowIdFullNull) ) {
+          // we are not the owner - can't change it
+          return false;
+      }
+      // owner the same -- we can change it
+      return true;
   }
 
 
@@ -1607,7 +1605,7 @@ public class AbstractPermissionsTestCase {
       boolean changeServerRowPath, boolean changeServerFormIdMetadata,
       boolean changeServerPrivilegedMetadata) {
 
-    ArrayList<SyncParamOutcome> cases = new ArrayList<SyncParamOutcome>();
+    ArrayList<SyncParamOutcome> cases = new ArrayList<>();
     String[] rowIds = { rowIdFullNull, rowIdFullCommon, rowIdHiddenCommon, rowIdReadOnlyCommon, rowIdModifyCommon };
 
     for ( String rowId : rowIds ) {
@@ -1712,7 +1710,7 @@ public class AbstractPermissionsTestCase {
       boolean changeServerRowPath, boolean changeServerFormIdMetadata,
       boolean changeServerPrivilegedMetadata) {
 
-    ArrayList<SyncParamOutcome> cases = new ArrayList<SyncParamOutcome>();
+    ArrayList<SyncParamOutcome> cases = new ArrayList<>();
     String[] rowIds = { rowIdFullNull, rowIdFullCommon, rowIdHiddenCommon, rowIdReadOnlyCommon, rowIdModifyCommon };
 
     for ( String rowId : rowIds ) {
@@ -1789,7 +1787,7 @@ public class AbstractPermissionsTestCase {
 
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListResolveTakeServer(String tableId) {
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
 
     int localConflict;
     int serverConflict;
@@ -1869,7 +1867,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListResolveTakeLocal(String tableId,
       boolean isLocked) {
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
 
     int localConflict;
     int serverConflict;
@@ -1958,7 +1956,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListUpdateUnlockedNoAnonCreate() {
     String tableId = testTableUnlockedNoAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can't modify hidden or read-only entries
     cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
         anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
@@ -2031,7 +2029,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListInsertUnlockedNoAnonCreate() {
     String tableId = testTableUnlockedNoAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can't insert
     cases.add(new AuthParamAndOutcome(tableId, rowIdInserted,
         anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
@@ -2054,7 +2052,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListDeleteUnlockedNoAnonCreate() {
     String tableId = testTableUnlockedNoAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can't delete, modify, hidden or read-only entries
     cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
         anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
@@ -2128,7 +2126,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildCheckpointOutcomesListDeleteUnlockedNoAnonCreate() {
     String tableId = testTableUnlockedNoAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can't delete, modify, hidden or read-only entries
     cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
             anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
@@ -2206,7 +2204,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListUpdateUnlockedYesAnonCreate() {
     String tableId = testTableUnlockedYesAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can't modify hidden or read-only entries
     cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
         anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
@@ -2279,7 +2277,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListInsertUnlockedYesAnonCreate() {
     String tableId = testTableUnlockedYesAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can insert
     cases.add(new AuthParamAndOutcome(tableId, rowIdInserted,
         anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
@@ -2302,7 +2300,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListDeleteUnlockedYesAnonCreate() {
     String tableId = testTableUnlockedYesAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can't delete modify, hidden or read-only entries
     cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
         anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
@@ -2375,7 +2373,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildCheckpointOutcomesListDeleteUnlockedYesAnonCreate() {
     String tableId = testTableUnlockedYesAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can't delete modify, hidden or read-only entries
     cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
             anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, false));
@@ -2452,7 +2450,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListUpdateLockedNoAnonCreate() {
     String tableId = testTableLockedNoAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can't modify anything other than the new row
     cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
         anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
@@ -2525,7 +2523,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListInsertLockedNoAnonCreate() {
     String tableId = testTableLockedNoAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can't insert
     cases.add(new AuthParamAndOutcome(tableId, rowIdInserted,
         anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
@@ -2548,7 +2546,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListDeleteLockedNoAnonCreate() {
     String tableId = testTableLockedNoAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can only delete new row
     cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
         anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
@@ -2621,7 +2619,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildCheckpointOutcomesListDeleteLockedNoAnonCreate() {
     String tableId = testTableLockedNoAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can only delete new row
     cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
             anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
@@ -2695,7 +2693,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListUpdateLockedYesAnonCreate() {
     String tableId = testTableLockedYesAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can't modify anything other than the new row
     cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
         anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
@@ -2768,7 +2766,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListInsertLockedYesAnonCreate() {
     String tableId = testTableLockedYesAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can't insert -- locking trumps allowing to create
     cases.add(new AuthParamAndOutcome(tableId, rowIdInserted,
         anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
@@ -2791,7 +2789,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildOutcomesListDeleteLockedYesAnonCreate() {
     String tableId = testTableLockedYesAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can't delete anything other than the new row
     cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
         anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));
@@ -2864,7 +2862,7 @@ public class AbstractPermissionsTestCase {
   protected ArrayList<AuthParamAndOutcome> buildCheckpointOutcomesListDeleteLockedYesAnonCreate() {
     String tableId = testTableLockedYesAnonCreate;
 
-    ArrayList<AuthParamAndOutcome> cases = new ArrayList<AuthParamAndOutcome>();
+    ArrayList<AuthParamAndOutcome> cases = new ArrayList<>();
     // anon user can't delete anything other than the new row
     cases.add(new AuthParamAndOutcome(tableId, rowIdFullNull,
             anonymousUser, RoleConsts.ANONYMOUS_ROLES_LIST, true));

--- a/services_app/src/androidTest/java/org/opendatakit/utilities/ChoiceListUtilsTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/utilities/ChoiceListUtilsTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Created by Niles on 6/29/17.
@@ -73,14 +74,14 @@ public class ChoiceListUtilsTest {
   }
 
   @Test
-  public void testSetChoiceList() throws Throwable {
+  public void testSetChoiceList() {
     ChoiceListUtils.setChoiceList(db, key, "my json");
     assertEquals(ChoiceListUtils.getChoiceList(db, key), "my json");
   }
 
   @Test
-  public void testGetChoiceListOnEmpty() throws Throwable {
-    assertEquals(ChoiceListUtils.getChoiceList(db, key), null);
+  public void testGetChoiceListOnEmpty() {
+      assertNull(ChoiceListUtils.getChoiceList(db, key));
   }
 
   @After

--- a/services_app/src/androidTest/java/org/opendatakit/utilities/ODKDatabaseUtilsConflictInteractionsPermissionsTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/utilities/ODKDatabaseUtilsConflictInteractionsPermissionsTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Permissions tests in the database.
@@ -43,7 +44,7 @@ public class ODKDatabaseUtilsConflictInteractionsPermissionsTest extends Abstrac
   private static final String TAG = "ODKDatabaseUtilsConflictInteractionsPermissionsTest";
 
   private void base_Type_ResolveLocalRow_Table(boolean isLocked, boolean canAnonCreate,
-      RowFilterScope.Access access) throws ActionNotAuthorizedException {
+      RowFilterScope.Access access) {
 
     String tableId;
     if ( isLocked ) {
@@ -90,14 +91,13 @@ public class ODKDatabaseUtilsConflictInteractionsPermissionsTest extends Abstrac
         assertTrue("Expecting to not throw an error: " + ex.toString() +" for " + ap.toString(),
             ap.throwsAccessException);
       } catch ( Exception ex ) {
-        assertTrue("Unexpected exception: " + ex.toString() +" for " + ap.toString(),
-            false);
+          fail("Unexpected exception: " + ex.toString() + " for " + ap.toString());
       }
     }
   }
 
   private void base_Type_ResolveLocalRowWithServerChanges_Table(boolean isLocked,
-      boolean canAnonCreate, RowFilterScope.Access access) throws ActionNotAuthorizedException {
+      boolean canAnonCreate, RowFilterScope.Access access) {
 
     String tableId;
     if ( isLocked ) {
@@ -157,14 +157,13 @@ public class ODKDatabaseUtilsConflictInteractionsPermissionsTest extends Abstrac
         assertTrue("Expecting to not throw an error: " + ex.toString() +" for " + ap.toString(),
             ap.throwsAccessException);
       } catch ( Exception ex ) {
-        assertTrue("Unexpected exception: " + ex.toString() +" for " + ap.toString(),
-            false);
+          fail("Unexpected exception: " + ex.toString() + " for " + ap.toString());
       }
     }
   }
 
   private void base_Type_ResolveServerRow_Table(boolean isLocked, boolean canAnonCreate,
-      RowFilterScope.Access access) throws ActionNotAuthorizedException {
+      RowFilterScope.Access access) {
 
     String tableId;
     if ( isLocked ) {
@@ -210,32 +209,31 @@ public class ODKDatabaseUtilsConflictInteractionsPermissionsTest extends Abstrac
         }
 
       } catch ( Exception ex ) {
-        assertTrue("Unexpected exception: " + ex.toString() +" for " + ap.toString(),
-            false);
+          fail("Unexpected exception: " + ex.toString() + " for " + ap.toString());
       }
     }
   }
 
   @Test
-  public void testResolveLocalRowUnlockedNoAnonCreate() throws ActionNotAuthorizedException {
+  public void testResolveLocalRowUnlockedNoAnonCreate() {
 
     base_Type_ResolveLocalRow_Table(false, false, RowFilterScope.Access.FULL);
   }
 
   @Test
-  public void testResolveLocalRowUnlockedYesAnonCreate() throws ActionNotAuthorizedException {
+  public void testResolveLocalRowUnlockedYesAnonCreate() {
 
     base_Type_ResolveLocalRow_Table(false, true, RowFilterScope.Access.FULL);
   }
 
   @Test
-  public void testResolveLocalRowLockedNoAnonCreate() throws ActionNotAuthorizedException {
+  public void testResolveLocalRowLockedNoAnonCreate() {
 
     base_Type_ResolveLocalRow_Table(true, false, RowFilterScope.Access.FULL);
   }
 
   @Test
-  public void testResolveLocalRowLockedYesAnonCreate() throws ActionNotAuthorizedException {
+  public void testResolveLocalRowLockedYesAnonCreate() {
 
     base_Type_ResolveLocalRow_Table(true, true, RowFilterScope.Access.FULL);
   }
@@ -243,26 +241,25 @@ public class ODKDatabaseUtilsConflictInteractionsPermissionsTest extends Abstrac
   ///////////////////
 
   @Test
-  public void testResolveLocalRowWithServerChangesUnlockedNoAnonCreate() throws
-      ActionNotAuthorizedException {
+  public void testResolveLocalRowWithServerChangesUnlockedNoAnonCreate() {
 
     base_Type_ResolveLocalRowWithServerChanges_Table(false, false, RowFilterScope.Access.FULL);
   }
 
   @Test
-  public void testResolveLocalRowWithServerChangesUnlockedYesAnonCreate() throws ActionNotAuthorizedException {
+  public void testResolveLocalRowWithServerChangesUnlockedYesAnonCreate() {
 
     base_Type_ResolveLocalRowWithServerChanges_Table(false, true, RowFilterScope.Access.FULL);
   }
 
   @Test
-  public void testResolveLocalRowWithServerChangesLockedNoAnonCreate() throws ActionNotAuthorizedException {
+  public void testResolveLocalRowWithServerChangesLockedNoAnonCreate() {
 
     base_Type_ResolveLocalRowWithServerChanges_Table(true, false, RowFilterScope.Access.FULL);
   }
 
   @Test
-  public void testResolveLocalRowWithServerChangesLockedYesAnonCreate() throws ActionNotAuthorizedException {
+  public void testResolveLocalRowWithServerChangesLockedYesAnonCreate() {
 
     base_Type_ResolveLocalRowWithServerChanges_Table(true, true, RowFilterScope.Access.FULL);
   }
@@ -270,25 +267,25 @@ public class ODKDatabaseUtilsConflictInteractionsPermissionsTest extends Abstrac
   ///////////////////
 
   @Test
-  public void testResolveServerRowUnlockedNoAnonCreate() throws ActionNotAuthorizedException {
+  public void testResolveServerRowUnlockedNoAnonCreate() {
 
     base_Type_ResolveServerRow_Table(false, false, RowFilterScope.Access.FULL);
   }
 
   @Test
-  public void testResolveServerRowUnlockedYesAnonCreate() throws ActionNotAuthorizedException {
+  public void testResolveServerRowUnlockedYesAnonCreate() {
 
     base_Type_ResolveServerRow_Table(false, true, RowFilterScope.Access.FULL);
   }
 
   @Test
-  public void testResolveServerRowLockedNoAnonCreate() throws ActionNotAuthorizedException {
+  public void testResolveServerRowLockedNoAnonCreate() {
 
     base_Type_ResolveServerRow_Table(true, false, RowFilterScope.Access.FULL);
   }
 
   @Test
-  public void testResolveServerRowLockedYesAnonCreate() throws ActionNotAuthorizedException {
+  public void testResolveServerRowLockedYesAnonCreate() {
 
     base_Type_ResolveServerRow_Table(true, true, RowFilterScope.Access.FULL);
   }

--- a/services_app/src/androidTest/java/org/opendatakit/utilities/ODKDatabaseUtilsDeletePermissionsTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/utilities/ODKDatabaseUtilsDeletePermissionsTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Permissions tests in the database.
@@ -37,7 +38,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
   private static final String TAG = "ODKDatabaseUtilsDeletePermissionsTest";
 
   @Test
-  public void testDeleteUnlockedNoAnonCreate() throws ActionNotAuthorizedException {
+  public void testDeleteUnlockedNoAnonCreate() {
 
     String tableId = testTableUnlockedNoAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable(testTableUnlockedNoAnonCreate,
@@ -78,7 +79,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
   }
 
   @Test
-  public void testDeleteUnlockedYesAnonCreate() throws ActionNotAuthorizedException {
+  public void testDeleteUnlockedYesAnonCreate() {
 
     String tableId = testTableUnlockedYesAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable(testTableUnlockedYesAnonCreate,
@@ -119,7 +120,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
   }
 
   @Test
-  public void testDeleteLockedNoAnonCreate() throws ActionNotAuthorizedException {
+  public void testDeleteLockedNoAnonCreate() {
 
     String tableId = testTableLockedNoAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable(testTableLockedNoAnonCreate,
@@ -160,7 +161,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
   }
 
   @Test
-  public void testDeleteLockedYesAnonCreate() throws ActionNotAuthorizedException {
+  public void testDeleteLockedYesAnonCreate() {
 
     String tableId = testTableLockedYesAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable(testTableLockedYesAnonCreate,
@@ -201,7 +202,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
   }
 
   @Test
-  public void testDeleteUnlockedNoAnonCreate0() throws ActionNotAuthorizedException {
+  public void testDeleteUnlockedNoAnonCreate0() {
 
     String tableId = testTableUnlockedNoAnonCreate;
     OrderedColumns oc = assertEmptyTestTable(testTableUnlockedNoAnonCreate,
@@ -225,13 +226,13 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
                 ap.toString()));
 
       } catch ( ActionNotAuthorizedException ex ) {
-        assertTrue("Expecting to not throw an error: " + ap.toString(), false);
+          fail("Expecting to not throw an error: " + ap.toString());
       }
     }
   }
 
   @Test
-  public void testDeleteUnlockedYesAnonCreate0() throws ActionNotAuthorizedException {
+  public void testDeleteUnlockedYesAnonCreate0() {
 
     String tableId = testTableUnlockedYesAnonCreate;
     OrderedColumns oc = assertEmptyTestTable(testTableUnlockedYesAnonCreate,
@@ -255,13 +256,13 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
                 ap.toString()));
 
       } catch ( ActionNotAuthorizedException ex ) {
-        assertTrue("Expecting to not throw an error: " + ap.toString(), false);
+          fail("Expecting to not throw an error: " + ap.toString());
       }
     }
   }
 
   @Test
-  public void testDeleteLockedNoAnonCreate0() throws ActionNotAuthorizedException {
+  public void testDeleteLockedNoAnonCreate0() {
 
     String tableId = testTableLockedNoAnonCreate;
     OrderedColumns oc = assertEmptyTestTable(testTableLockedNoAnonCreate,
@@ -285,13 +286,13 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
                 ap.toString()));
 
       } catch ( ActionNotAuthorizedException ex ) {
-        assertTrue("Expecting to not throw an error: " + ap.toString(), false);
+          fail("Expecting to not throw an error: " + ap.toString());
       }
     }
   }
 
   @Test
-  public void testDeleteLockedYesAnonCreate0() throws ActionNotAuthorizedException {
+  public void testDeleteLockedYesAnonCreate0() {
 
     String tableId = testTableLockedYesAnonCreate;
     OrderedColumns oc = assertEmptyTestTable(testTableLockedYesAnonCreate,
@@ -315,7 +316,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
                 ap.toString()));
 
       } catch ( ActionNotAuthorizedException ex ) {
-        assertTrue("Expecting to not throw an error: " + ap.toString(), false);
+          fail("Expecting to not throw an error: " + ap.toString());
       }
     }
   }
@@ -859,8 +860,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
   }
 
   @Test
-  public void testDeleteAllCheckpointsAsUpdateUnlockedNoAnonCreate0()
-      throws  ActionNotAuthorizedException {
+  public void testDeleteAllCheckpointsAsUpdateUnlockedNoAnonCreate0() {
 
     String tableId = testTableUnlockedNoAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable
@@ -898,14 +898,13 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         }
 
       } catch (ActionNotAuthorizedException ex) {
-        assertTrue("Expecting to not throw an error: " + ap.toString(), false);
+          fail("Expecting to not throw an error: " + ap.toString());
       }
     }
   }
 
   @Test
-  public void testDeleteAllCheckpointsAsUpdateUnlockedYesAnonCreate0()
-      throws  ActionNotAuthorizedException {
+  public void testDeleteAllCheckpointsAsUpdateUnlockedYesAnonCreate0() {
 
     String tableId = testTableUnlockedYesAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable
@@ -944,14 +943,13 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         }
 
       } catch (ActionNotAuthorizedException ex) {
-        assertTrue("Expecting to not throw an error: " + ap.toString(), false);
+          fail("Expecting to not throw an error: " + ap.toString());
       }
     }
   }
 
   @Test
-  public void testDeleteAllCheckpointsAsUpdateLockedNoAnonCreate0()
-      throws  ActionNotAuthorizedException {
+  public void testDeleteAllCheckpointsAsUpdateLockedNoAnonCreate0() {
 
     String tableId = testTableLockedNoAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable
@@ -990,14 +988,13 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         }
 
       } catch (ActionNotAuthorizedException ex) {
-        assertTrue("Expecting to not throw an error: " + ap.toString(), false);
+          fail("Expecting to not throw an error: " + ap.toString());
       }
     }
   }
 
   @Test
-  public void testDeleteAllCheckpointsAsUpdateLockedYesAnonCreate0()
-      throws  ActionNotAuthorizedException {
+  public void testDeleteAllCheckpointsAsUpdateLockedYesAnonCreate0() {
 
     String tableId = testTableLockedYesAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable
@@ -1036,7 +1033,7 @@ public class ODKDatabaseUtilsDeletePermissionsTest extends AbstractPermissionsTe
         }
 
       } catch (ActionNotAuthorizedException ex) {
-        assertTrue("Expecting to not throw an error: " + ap.toString(), false);
+          fail("Expecting to not throw an error: " + ap.toString());
       }
     }
   }

--- a/services_app/src/androidTest/java/org/opendatakit/utilities/ODKDatabaseUtilsInsertUpdatePermissionsTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/utilities/ODKDatabaseUtilsInsertUpdatePermissionsTest.java
@@ -39,7 +39,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   private static final String TAG = "ODKDatabaseUtilsInsertUpdatePermissionsTest";
 
   @Test
-  public void testUpdateUnlockedNoAnonCreate() throws ActionNotAuthorizedException {
+  public void testUpdateUnlockedNoAnonCreate() {
 
     String tableId = testTableUnlockedNoAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable(testTableUnlockedNoAnonCreate,
@@ -64,8 +64,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
 
 
   @Test
-  public void testInsertCheckpointAsUpdateUnlockedNoAnonCreate()
-      throws  ActionNotAuthorizedException {
+  public void testInsertCheckpointAsUpdateUnlockedNoAnonCreate() {
 
     String tableId = testTableUnlockedNoAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable(testTableUnlockedNoAnonCreate,
@@ -89,7 +88,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   }
 
   @Test
-  public void testInsertUnlockedNoAnonCreate() throws ActionNotAuthorizedException {
+  public void testInsertUnlockedNoAnonCreate() {
 
     String tableId = testTableUnlockedNoAnonCreate;
     OrderedColumns oc = assertEmptyTestTable(testTableUnlockedNoAnonCreate,
@@ -112,8 +111,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   }
 
   @Test
-  public void testInsertCheckpointAsInsertUnlockedNoAnonCreate()
-      throws ActionNotAuthorizedException {
+  public void testInsertCheckpointAsInsertUnlockedNoAnonCreate() {
 
     String tableId = testTableUnlockedNoAnonCreate;
     OrderedColumns oc = assertEmptyTestTable(testTableUnlockedNoAnonCreate,
@@ -136,7 +134,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   }
 
   @Test
-  public void testUpdateUnlockedYesAnonCreate() throws ActionNotAuthorizedException {
+  public void testUpdateUnlockedYesAnonCreate() {
 
     String tableId = testTableUnlockedYesAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable(testTableUnlockedYesAnonCreate,
@@ -160,8 +158,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   }
 
   @Test
-  public void testInsertCheckpointAsUpdateUnlockedYesAnonCreate()
-      throws  ActionNotAuthorizedException {
+  public void testInsertCheckpointAsUpdateUnlockedYesAnonCreate() {
 
     String tableId = testTableUnlockedYesAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable(testTableUnlockedYesAnonCreate,
@@ -186,7 +183,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   }
 
   @Test
-  public void testInsertUnlockedYesAnonCreate() throws ActionNotAuthorizedException {
+  public void testInsertUnlockedYesAnonCreate() {
 
     String tableId = testTableUnlockedYesAnonCreate;
     OrderedColumns oc = assertEmptyTestTable(testTableUnlockedYesAnonCreate,
@@ -209,8 +206,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   }
 
   @Test
-  public void testInsertCheckpointAsInsertUnlockedYesAnonCreate()
-      throws ActionNotAuthorizedException {
+  public void testInsertCheckpointAsInsertUnlockedYesAnonCreate() {
 
     String tableId = testTableUnlockedYesAnonCreate;
     OrderedColumns oc = assertEmptyTestTable(testTableUnlockedYesAnonCreate,
@@ -233,7 +229,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   }
 
   @Test
-  public void testUpdateLockedNoAnonCreate() throws ActionNotAuthorizedException {
+  public void testUpdateLockedNoAnonCreate() {
 
     String tableId = testTableLockedNoAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable(testTableLockedNoAnonCreate,
@@ -258,7 +254,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
 
 
   @Test
-  public void testInsertCheckpointAsUpdateLockedNoAnonCreate() throws ActionNotAuthorizedException {
+  public void testInsertCheckpointAsUpdateLockedNoAnonCreate() {
 
     String tableId = testTableLockedNoAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable(testTableLockedNoAnonCreate,
@@ -282,7 +278,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   }
 
   @Test
-  public void testInsertLockedNoAnonCreate() throws ActionNotAuthorizedException {
+  public void testInsertLockedNoAnonCreate() {
 
     String tableId = testTableLockedNoAnonCreate;
     OrderedColumns oc = assertEmptyTestTable(testTableLockedNoAnonCreate,
@@ -305,7 +301,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   }
 
   @Test
-  public void testInsertCheckpointAsInsertLockedNoAnonCreate() throws ActionNotAuthorizedException {
+  public void testInsertCheckpointAsInsertLockedNoAnonCreate() {
 
     String tableId = testTableLockedNoAnonCreate;
     OrderedColumns oc = assertEmptyTestTable(testTableLockedNoAnonCreate,
@@ -328,7 +324,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   }
 
   @Test
-  public void testUpdateLockedYesAnonCreate() throws ActionNotAuthorizedException {
+  public void testUpdateLockedYesAnonCreate() {
 
     String tableId = testTableLockedYesAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable(testTableLockedYesAnonCreate,
@@ -352,8 +348,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   }
 
   @Test
-  public void testInsertCheckpointAsUpdateLockedYesAnonCreate() throws
-      ActionNotAuthorizedException {
+  public void testInsertCheckpointAsUpdateLockedYesAnonCreate() {
 
     String tableId = testTableLockedYesAnonCreate;
     OrderedColumns oc = assertPopulatedTestTable(testTableLockedYesAnonCreate,
@@ -377,7 +372,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   }
 
   @Test
-  public void testInsertLockedYesAnonCreate() throws ActionNotAuthorizedException {
+  public void testInsertLockedYesAnonCreate() {
 
     String tableId = testTableLockedYesAnonCreate;
     OrderedColumns oc = assertEmptyTestTable(testTableLockedYesAnonCreate,
@@ -400,8 +395,7 @@ public class ODKDatabaseUtilsInsertUpdatePermissionsTest extends AbstractPermiss
   }
 
   @Test
-  public void testInsertCheckpointAsInsertLockedYesAnonCreate()
-      throws ActionNotAuthorizedException {
+  public void testInsertCheckpointAsInsertLockedYesAnonCreate() {
 
     String tableId = testTableLockedYesAnonCreate;
     OrderedColumns oc = assertEmptyTestTable(testTableLockedYesAnonCreate,

--- a/services_app/src/androidTest/java/org/opendatakit/webkitserver/service/OdkWebserverServiceTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/webkitserver/service/OdkWebserverServiceTest.java
@@ -10,7 +10,7 @@ import android.os.IBinder;
 import android.os.RemoteException;
 
 import androidx.annotation.NonNull;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.rule.ServiceTestRule;
 
@@ -34,8 +34,9 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -73,7 +74,7 @@ public class OdkWebserverServiceTest {
     @After
     public void tearDown() {
         IWebkitServerInterface webkitServer = getIWebkitServerInterface();
-        Context context = InstrumentationRegistry.getContext();
+        Context context = InstrumentationRegistry.getInstrumentation().getContext();
         context.unbindService(odkWebkitServiceConnection);
         // sleep to let this take effect
         try {
@@ -132,7 +133,7 @@ public class OdkWebserverServiceTest {
         synchronized (odkWebkitInterfaceBindComplete) {
             if ( !active ) {
                 active = true;
-                Context context = InstrumentationRegistry.getContext();
+                Context context = InstrumentationRegistry.getInstrumentation().getContext();
                 context.bindService(bind_intent, odkWebkitServiceConnection,
                     Context.BIND_AUTO_CREATE | ((Build.VERSION.SDK_INT >= 14) ?
                         Context.BIND_ADJUST_WITH_ACTIVITY :
@@ -219,7 +220,7 @@ public class OdkWebserverServiceTest {
         HttpURLConnection connection = null;
         try {
             String urlStr = "http://" + WebkitServerConsts.HOSTNAME + ":" +
-                Integer.toString(WebkitServerConsts.PORT) + "/" + TestConsts.APPNAME + "/" +
+                    WebkitServerConsts.PORT + "/" + TestConsts.APPNAME + "/" +
                 ODKFileUtils.asUriFragment(TestConsts.APPNAME, fileLocation);
 
             URL url = new URL(urlStr);
@@ -228,15 +229,15 @@ public class OdkWebserverServiceTest {
                 fail("Response code was NOT HTTP_OK");
             }
             BufferedReader br = new BufferedReader(new InputStreamReader(connection
-                .getInputStream(), "UTF-8"));
-            String responseStr = "";
+                .getInputStream(), StandardCharsets.UTF_8));
+            StringBuilder responseStr = new StringBuilder();
             String segment = br.readLine();
             while (segment != null) {
-                responseStr = responseStr + segment;
+                responseStr.append(segment);
                 segment = br.readLine();
             }
             br.close();
-            assertTrue("RECEIVED:" + responseStr, HELLO_WORLD_HTML_TXT.equals(responseStr));
+            assertEquals("RECEIVED:" + responseStr, HELLO_WORLD_HTML_TXT, responseStr.toString());
         } catch(IOException e) {
             e.printStackTrace();
             fail("GOT an IOException when trying to use the web server:" + e.getMessage());


### PR DESCRIPTION
This PR:
- Replaces deprecated InstrumentationRegistry.getContext() with ApplicationProvider.getApplicationContext() in ODKServiceTestRule and OdkDatabaseTestAbstractBase class.
- Simplify assertions
- Fix null pointer warning
- Clean up code