### PR TITLE
Update Android Tests

### DIFF
--- a/services_app/src/androidTest/java/org/opendatakit/database/service/ODKServiceTestRule.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/ODKServiceTestRule.java
@@ -28,12 +28,13 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
 import androidx.annotation.NonNull;
-import androidx.test.core.app.ApplicationProvider;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.internal.util.Checks;
 import android.util.Log;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -188,7 +189,7 @@ public class ODKServiceTestRule implements TestRule {
 
       for(int i=0; i < MAX_CONNECTION_ATTEMPTS; i++) {
 
-         boolean isBound = ApplicationProvider.getApplicationContext().bindService(intent, servConn, flags);
+         boolean isBound = InstrumentationRegistry.getInstrumentation().getContext().bindService(intent, servConn, flags);
 
          // block until service connection is established
          if (isBound) {
@@ -234,9 +235,9 @@ public class ODKServiceTestRule implements TestRule {
          } catch (InterruptedException e) {
             e.printStackTrace();
          }
-          assert conn != null;
-          if(!conn.binderIsNull()) {
-             ApplicationProvider.getApplicationContext().unbindService(conn);
+          assertNotNull(conn);
+         if(!conn.binderIsNull()) {
+            InstrumentationRegistry.getInstrumentation().getContext().unbindService(conn);
             Log.e(TAG, "CALLED UNBIND");
          }
       }

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/ODKServiceTestRule.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/ODKServiceTestRule.java
@@ -28,7 +28,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
 import androidx.annotation.NonNull;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.internal.util.Checks;
 import android.util.Log;
 import org.junit.rules.TestRule;
@@ -69,7 +69,7 @@ public class ODKServiceTestRule implements TestRule {
    private ODKServiceTestRule(long timeout, TimeUnit timeUnit) {
       mTimeout = timeout;
       mTimeUnit = timeUnit;
-      mAttemptToBindConnections = new LinkedBlockingQueue<ProxyServiceConnection>();
+      mAttemptToBindConnections = new LinkedBlockingQueue<>();
    }
 
 
@@ -188,7 +188,7 @@ public class ODKServiceTestRule implements TestRule {
 
       for(int i=0; i < MAX_CONNECTION_ATTEMPTS; i++) {
 
-         boolean isBound = InstrumentationRegistry.getContext().bindService(intent, servConn, flags);
+         boolean isBound = InstrumentationRegistry.getInstrumentation().getContext().bindService(intent, servConn, flags);
 
          // block until service connection is established
          if (isBound) {
@@ -225,7 +225,7 @@ public class ODKServiceTestRule implements TestRule {
     * reliable way to guarantee successful disconnect without access to service lifecycle.
     */
    // Visible for testing
-   void shutdownService() throws TimeoutException {
+   void shutdownService() {
       Log.e(TAG, "READY TO UNBIND");
       while (!mAttemptToBindConnections.isEmpty()) {
          ProxyServiceConnection conn = null;
@@ -234,8 +234,9 @@ public class ODKServiceTestRule implements TestRule {
          } catch (InterruptedException e) {
             e.printStackTrace();
          }
-         if(!conn.binderIsNull()) {
-            InstrumentationRegistry.getContext().unbindService(conn);
+          assert conn != null;
+          if(!conn.binderIsNull()) {
+             InstrumentationRegistry.getInstrumentation().getContext().unbindService(conn);
             Log.e(TAG, "CALLED UNBIND");
          }
       }

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/ODKServiceTestRule.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/ODKServiceTestRule.java
@@ -28,7 +28,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
 import androidx.annotation.NonNull;
-import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.internal.util.Checks;
 import android.util.Log;
 import org.junit.rules.TestRule;
@@ -188,7 +188,7 @@ public class ODKServiceTestRule implements TestRule {
 
       for(int i=0; i < MAX_CONNECTION_ATTEMPTS; i++) {
 
-         boolean isBound = InstrumentationRegistry.getInstrumentation().getContext().bindService(intent, servConn, flags);
+         boolean isBound = ApplicationProvider.getApplicationContext().bindService(intent, servConn, flags);
 
          // block until service connection is established
          if (isBound) {
@@ -236,7 +236,7 @@ public class ODKServiceTestRule implements TestRule {
          }
           assert conn != null;
           if(!conn.binderIsNull()) {
-             InstrumentationRegistry.getInstrumentation().getContext().unbindService(conn);
+             ApplicationProvider.getApplicationContext().unbindService(conn);
             Log.e(TAG, "CALLED UNBIND");
          }
       }

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseTestAbstractBase.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseTestAbstractBase.java
@@ -1,14 +1,20 @@
 package org.opendatakit.database.service;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
+import android.util.Log;
+
 import androidx.annotation.Nullable;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.rule.ServiceTestRule;
-import android.util.Log;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -19,9 +25,6 @@ import org.opendatakit.services.database.AndroidConnectFactory;
 
 import java.util.List;
 import java.util.concurrent.TimeoutException;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Created by wrb on 9/26/2017.
@@ -63,6 +66,7 @@ abstract class OdkDatabaseTestAbstractBase {
       tearDownBefore();
       UserDbInterface serviceInterface = bindToDbService();
       try {
+          assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("OdkDatabaseServiceTest", "tearDown: " + db.getDatabaseHandle());
          verifyNoTablesExistNCleanAllTables(serviceInterface, db);
@@ -74,7 +78,7 @@ abstract class OdkDatabaseTestAbstractBase {
    }
 
    @Nullable protected UserDbInterfaceImpl bindToDbService() {
-      Context context = InstrumentationRegistry.getContext();
+      Context context = ApplicationProvider.getApplicationContext();
 
       ++bindToDbServiceCount;
       Intent bind_intent = new Intent();

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseTestAbstractBase.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseTestAbstractBase.java
@@ -11,7 +11,7 @@ import android.os.IBinder;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
-import androidx.test.core.app.ApplicationProvider;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.rule.ServiceTestRule;
 
@@ -78,7 +78,7 @@ abstract class OdkDatabaseTestAbstractBase {
    }
 
    @Nullable protected UserDbInterfaceImpl bindToDbService() {
-      Context context = ApplicationProvider.getApplicationContext();
+      Context context = InstrumentationRegistry.getInstrumentation().getContext();
 
       ++bindToDbServiceCount;
       Intent bind_intent = new Intent();

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseTypesTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseTypesTest.java
@@ -137,34 +137,34 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
    }
 
    private void verifyRowTestSet1(TypedRow row) {
-      assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) TEST_INT_1);
+      assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(TEST_INT_1));
       assertNull(row.getDataByKey(COL_NUMBER_ID));
-      assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.TRUE);
+      assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.valueOf(TEST_BOOL_1));
       assertNull(row.getDataByKey(COL_ROWPATH_ID));
       assertNull(row.getDataByKey(COL_CONFIGPATH_ID));
       assertNull(row.getDataByKey(COL_ARRAY_ID));
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
 
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ACC), TEST_NUM_1);
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ALT), TEST_NUM_1);
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LAT), TEST_NUM_1);
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LONG), TEST_NUM_1);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ACC), Double.valueOf(TEST_NUM_1));
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ALT), Double.valueOf(TEST_NUM_1));
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LAT), Double.valueOf(TEST_NUM_1));
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LONG), Double.valueOf(TEST_NUM_1));
 
    }
 
    private void verifyRowTestSeti(TypedRow row, int i) {
-      assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) (TEST_INT_i + i));
-      assertEquals(row.getDataByKey(COL_NUMBER_ID), TEST_NUM_i + i);
-      assertEquals(row.getDataByKey(COL_BOOL_ID), (i % 2 != 0));
+      assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(TEST_INT_i + i));
+      assertEquals(row.getDataByKey(COL_NUMBER_ID), Double.valueOf(TEST_NUM_i + i));
+      assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.valueOf((i % 2 != 0)));
       assertEquals(row.getDataByKey(COL_ROWPATH_ID), TEST_ROWPATH_i + i);
       assertEquals(row.getDataByKey(COL_CONFIGPATH_ID), TEST_CONFIGPATH_i + i);
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_i + i);
 
       assertEquals(row.getDataByKey(COL_ARRAY_ID), TEST_ARRAY_i_CHECK);
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ACC), TEST_NUM_i + i);
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ALT), TEST_NUM_i + i);
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LAT), TEST_NUM_i + i);
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LONG), TEST_NUM_i + i);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ACC), Double.valueOf(TEST_NUM_i + i));
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ALT), Double.valueOf(TEST_NUM_i + i));
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LAT), Double.valueOf(TEST_NUM_i + i));
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LONG), Double.valueOf(TEST_NUM_i + i));
    }
 
    @Test public void testDbInsertSingleRowIntoTable() throws ActionNotAuthorizedException {
@@ -369,7 +369,7 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
             TypedRow row = new TypedRow(table.getRowAtIndex(0), columns);
             Object value = row.getDataByKey("Total");
             if (value instanceof String) {
-               int count = Integer.parseInt((String) value);
+               int count = Integer.valueOf((String) value);
                assertEquals(numRows, count);
             } else {
                fail("Should have returned a string because type of column was unknown");

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseTypesTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseTypesTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -59,7 +60,7 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
    private static final String TEST_STR_i = "TestBoolStr";
    private static final String TEST_ARRAY_i = "[\"Test1\",\"Test2\"]";
 
-   private static final ArrayList<String> TEST_ARRAY_i_CHECK = new ArrayList<String>();
+   private static final ArrayList<String> TEST_ARRAY_i_CHECK = new ArrayList<>();
 
    static {
       TEST_ARRAY_i_CHECK.addAll(Arrays.asList("Test1", "Test2"));
@@ -74,7 +75,7 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
    }
 
    @NonNull private List<Column> createColumnList() {
-      List<Column> columns = new ArrayList<Column>();
+      List<Column> columns = new ArrayList<>();
 
       columns
           .add(new Column(COL_INTEGER_ID, "column Integer", ElementDataType.integer.name(), null));
@@ -136,34 +137,34 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
    }
 
    private void verifyRowTestSet1(TypedRow row) {
-      assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(TEST_INT_1));
+      assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) TEST_INT_1);
       assertNull(row.getDataByKey(COL_NUMBER_ID));
-      assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.valueOf(TEST_BOOL_1));
+      assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.TRUE);
       assertNull(row.getDataByKey(COL_ROWPATH_ID));
       assertNull(row.getDataByKey(COL_CONFIGPATH_ID));
       assertNull(row.getDataByKey(COL_ARRAY_ID));
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
 
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ACC), Double.valueOf(TEST_NUM_1));
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ALT), Double.valueOf(TEST_NUM_1));
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LAT), Double.valueOf(TEST_NUM_1));
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LONG), Double.valueOf(TEST_NUM_1));
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ACC), TEST_NUM_1);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ALT), TEST_NUM_1);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LAT), TEST_NUM_1);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LONG), TEST_NUM_1);
 
    }
 
    private void verifyRowTestSeti(TypedRow row, int i) {
-      assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(TEST_INT_i + i));
-      assertEquals(row.getDataByKey(COL_NUMBER_ID), Double.valueOf(TEST_NUM_i + i));
-      assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.valueOf((i % 2 != 0)));
+      assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) (TEST_INT_i + i));
+      assertEquals(row.getDataByKey(COL_NUMBER_ID), TEST_NUM_i + i);
+      assertEquals(row.getDataByKey(COL_BOOL_ID), (i % 2 != 0));
       assertEquals(row.getDataByKey(COL_ROWPATH_ID), TEST_ROWPATH_i + i);
       assertEquals(row.getDataByKey(COL_CONFIGPATH_ID), TEST_CONFIGPATH_i + i);
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_i + i);
 
       assertEquals(row.getDataByKey(COL_ARRAY_ID), TEST_ARRAY_i_CHECK);
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ACC), Double.valueOf(TEST_NUM_i + i));
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ALT), Double.valueOf(TEST_NUM_i + i));
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LAT), Double.valueOf(TEST_NUM_i + i));
-      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LONG), Double.valueOf(TEST_NUM_i + i));
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ACC), TEST_NUM_i + i);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_ALT), TEST_NUM_i + i);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LAT), TEST_NUM_i + i);
+      assertEquals(row.getDataByKey(COL_GEO_OBJ_ID_LONG), TEST_NUM_i + i);
    }
 
    @Test public void testDbInsertSingleRowIntoTable() throws ActionNotAuthorizedException {
@@ -174,7 +175,8 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbInsertSingleRowIntoTable: " + db.getDatabaseHandle());
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, colList);
 
@@ -227,7 +229,8 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          db = serviceInterface.openDatabase(APPNAME);
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, colList);
 
          OrderedColumns columns = new OrderedColumns(APPNAME, DB_TABLE_ID, columnList);
@@ -292,6 +295,7 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+         assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase",
              "testDbInsertCheckpointRowWithBooleanIntoTable: " + db.getDatabaseHandle());
@@ -334,7 +338,8 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
          OrderedColumns columns = new OrderedColumns(APPNAME, DB_TABLE_ID, columnList);
-         db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase",
              "testDbInsertCheckpointRowWithBooleanIntoTable: " + db.getDatabaseHandle());
 
@@ -364,7 +369,7 @@ public class OdkDatabaseTypesTest extends OdkDatabaseTestAbstractBase {
             TypedRow row = new TypedRow(table.getRowAtIndex(0), columns);
             Object value = row.getDataByKey("Total");
             if (value instanceof String) {
-               int count = Integer.valueOf((String) value);
+               int count = Integer.parseInt((String) value);
                assertEquals(numRows, count);
             } else {
                fail("Should have returned a string because type of column was unknown");

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/SyncETagsUtilsTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/SyncETagsUtilsTest.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,7 +45,8 @@ public class SyncETagsUtilsTest extends OdkDatabaseTestAbstractBase {
    protected void setUpBefore() {
       try {
          serviceInterface = bindToDbService();
-         dbHandle = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          dbHandle = serviceInterface.openDatabase(APPNAME);
 
       } catch (Exception e) {
          e.printStackTrace();
@@ -380,7 +382,7 @@ public class SyncETagsUtilsTest extends OdkDatabaseTestAbstractBase {
 
    private void expectGone(String id, boolean isManifest) throws ServicesAvailabilityException {
       UserTable c = get(id, isManifest);
-      assertTrue(c.getNumberOfRows() == 0);
+       assertEquals(0, c.getNumberOfRows());
    }
 
    private void expectPresent(String id, boolean isManifest) throws ServicesAvailabilityException {


### PR DESCRIPTION
This PR:
- Replaces deprecated InstrumentationRegistry.getContext() with ApplicationProvider.getApplicationContext() in ODKServiceTestRule and OdkDatabaseTestAbstractBase class.
- Simplify assertions
- Fix null pointer warning
- Clean up code