### PR TITLE
Outreachy week nine/update android tests

### DIFF
--- a/services_app/src/androidTest/java/org/opendatakit/database/service/GroupsPermissionTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/GroupsPermissionTest.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.After;
@@ -139,7 +140,7 @@ public class GroupsPermissionTest {
    }
 
    @Nullable private UserDbInterface bindToDbService() {
-      Context context = ApplicationProvider.getApplicationContext();
+      Context context = InstrumentationRegistry.getInstrumentation().getContext();
       Intent bind_intent = new Intent();
       bind_intent.setClassName(IntentConsts.Database.DATABASE_SERVICE_PACKAGE,
           IntentConsts.Database.DATABASE_SERVICE_CLASS);
@@ -196,8 +197,8 @@ public class GroupsPermissionTest {
    private void verifyRowTestSeti(TypedRow row, int i, String groupReadOnly, String groupModify,
        String groupPrivileged) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_i + i);
-      assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) (TEST_INT_i + i));
-      assertEquals(row.getDataByKey(COL_NUMBER_ID), TEST_NUM_i + i);
+      assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(TEST_INT_i + i));
+      assertEquals(row.getDataByKey(COL_NUMBER_ID), Double.valueOf(TEST_NUM_i + i));
       assertEquals(groupReadOnly, row.getDataByKey(DataTableColumns.GROUP_READ_ONLY));
       assertEquals(groupModify, row.getDataByKey(DataTableColumns.GROUP_MODIFY));
       assertEquals(groupPrivileged, row.getDataByKey(DataTableColumns.GROUP_PRIVILEGED));
@@ -220,8 +221,8 @@ public class GroupsPermissionTest {
 
    private void verifyRowTestSet1(TypedRow row) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
-      assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) TEST_INT_1);
-      assertEquals(row.getDataByKey(COL_NUMBER_ID), TEST_NUM_1);
+      assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(TEST_INT_1));
+      assertEquals(row.getDataByKey(COL_NUMBER_ID), Double.valueOf(TEST_NUM_1));
       assertEquals(row.getRawStringByKey(DataTableColumns.DEFAULT_ACCESS),
               RowFilterScope.Access.FULL.name());
       assertEquals(TEST_GROUP_1, row.getRawStringByKey(DataTableColumns.GROUP_MODIFY));
@@ -601,7 +602,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(2L,row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -727,7 +728,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(2L,row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -857,7 +858,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(2L, row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(2), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getRawStringByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getRawStringByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -986,7 +987,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(2L,row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -1057,7 +1058,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(3L,row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(3),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1083,7 +1084,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          TypedRow row = table.getRowAtIndex(0);
 
-         assertEquals(4L, row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(4), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_3, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1197,7 +1198,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(2L,row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1246,7 +1247,7 @@ public class GroupsPermissionTest {
          assertEquals(DB_TABLE_ID, table.getTableId());
          assertEquals(1, table.getNumberOfRows());
          TypedRow row = table.getRowAtIndex(0);
-         assertEquals(2L, row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(2), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1268,7 +1269,7 @@ public class GroupsPermissionTest {
          assertEquals(DB_TABLE_ID, table.getTableId());
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
-         assertEquals(3L, row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(3), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_3, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1393,7 +1394,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(2L,row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -1484,7 +1485,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(2L,row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1519,7 +1520,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(3L, row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(3), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1551,7 +1552,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(4L, row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(4), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1563,7 +1564,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(4L, row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(4), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1682,7 +1683,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(2L,row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -1772,7 +1773,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(2L,row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1807,7 +1808,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(3L, row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(3), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1839,7 +1840,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(4L, row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(4), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1851,7 +1852,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(4L, row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(4), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/GroupsPermissionTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/GroupsPermissionTest.java
@@ -64,6 +64,9 @@ public class GroupsPermissionTest {
    private static final String TEST_STR_i = "TestStri";
    private static final int TEST_INT_i = 0;
    private static final double TEST_NUM_i = 0.1;
+   public static final int COL_INTEGER_VALUE_TWO = 2;
+   public static final int COL_INTEGER_VALUE_THREE = 3;
+   public static final int COL_INTEGER_VALUE_FOUR = 4;
 
    private static final String TEST_GROUP_1 = "GROUP_ONE";
    private static final String TEST_USER_1 = "testUsr1@gmail.com";
@@ -587,7 +590,7 @@ public class GroupsPermissionTest {
          TypedRow row = table.getRowAtIndex(0);
 
          ContentValues cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 2);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_TWO);
          cv.put(DataTableColumns.SYNC_STATE, SyncState.synced.name());
 
          assertEquals(rowId.toString(), row.getDataByKey
@@ -602,7 +605,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -622,7 +625,7 @@ public class GroupsPermissionTest {
          TypedRow row = table.getRowAtIndex(0);
 
          ContentValues cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 3);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_THREE);
          serviceInterface.updateRowWithId(APPNAME, db, DB_TABLE_ID, columns, cv, rowId.toString());
          fail("Should have thrown an ActionNotAuthorizedException");
       } catch (ActionNotAuthorizedException e) {
@@ -718,7 +721,7 @@ public class GroupsPermissionTest {
 
          // verify user 2 can change value
          cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 2);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_TWO);
          serviceInterface.updateRowWithId(APPNAME, db, DB_TABLE_ID, columns, cv, rowId.toString());
 
          // verify the change
@@ -728,7 +731,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -843,7 +846,7 @@ public class GroupsPermissionTest {
          TypedRow row = table.getRowAtIndex(0);
 
          ContentValues cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 2);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_TWO);
          cv.put(DataTableColumns.SYNC_STATE, SyncState.synced.name());
 
          assertEquals(rowId.toString(), row.getRawStringByKey(DataTableColumns.ID));
@@ -858,7 +861,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(2), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getRawStringByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getRawStringByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -971,7 +974,7 @@ public class GroupsPermissionTest {
          TypedRow row = table.getRowAtIndex(0);
 
          ContentValues cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 2);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_TWO);
          cv.put(DataTableColumns.SYNC_STATE, SyncState.synced.name());
 
          assertEquals(rowId.toString(), row.getDataByKey
@@ -987,7 +990,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -1009,7 +1012,7 @@ public class GroupsPermissionTest {
          TypedRow row = table.getRowAtIndex(0);
 
          ContentValues cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 3);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_THREE);
          serviceInterface.updateRowWithId(APPNAME, db, DB_TABLE_ID, columns, cv, rowId.toString());
          fail("Should have thrown an ActionNotAuthorizedException");
       } catch (ActionNotAuthorizedException e) {
@@ -1023,7 +1026,7 @@ public class GroupsPermissionTest {
       try {
          switchToUser3(serviceInterface);
          ContentValues cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 3);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_THREE);
          serviceInterface.updateRowWithId(APPNAME, db, DB_TABLE_ID, columns, cv, rowId.toString());
          fail("Should have thrown an ActionNotAuthorizedException");
       }  catch (ActionNotAuthorizedException e) {
@@ -1043,7 +1046,7 @@ public class GroupsPermissionTest {
          TypedRow row = table.getRowAtIndex(0);
 
          ContentValues cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 3);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_THREE);
          cv.put(DataTableColumns.GROUP_PRIVILEGED, TEST_GRP_3);
 
          assertEquals(rowId.toString(), row.getDataByKey
@@ -1058,7 +1061,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(3),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_THREE),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1075,7 +1078,7 @@ public class GroupsPermissionTest {
       try {
          switchToUser3(serviceInterface);
          ContentValues cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 4);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_FOUR);
          serviceInterface.updateRowWithId(APPNAME, db, DB_TABLE_ID, columns, cv, rowId.toString());
 
          UserTable table = serviceInterface
@@ -1084,7 +1087,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          TypedRow row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(4), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_FOUR), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_3, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1180,7 +1183,7 @@ public class GroupsPermissionTest {
          row = table.getRowAtIndex(0);
 
          ContentValues cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 2);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_TWO);
          cv.put(DataTableColumns.DEFAULT_ACCESS, RowFilterScope.Access.HIDDEN.name());
          cv.put(DataTableColumns.SYNC_STATE, SyncState.synced.name());
 
@@ -1198,7 +1201,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1227,7 +1230,7 @@ public class GroupsPermissionTest {
 
          // user three attempts to update a read only row
          cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 3);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_THREE);
          serviceInterface.updateRowWithId(APPNAME, db, DB_TABLE_ID, columns, cv, rowId.toString());
          fail("Should have thrown an ActionNotAuthorizedException");
       } catch (ActionNotAuthorizedException e) {
@@ -1247,7 +1250,7 @@ public class GroupsPermissionTest {
          assertEquals(DB_TABLE_ID, table.getTableId());
          assertEquals(1, table.getNumberOfRows());
          TypedRow row = table.getRowAtIndex(0);
-         assertEquals(Long.valueOf(2), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1261,7 +1264,7 @@ public class GroupsPermissionTest {
          // verify user 3 can update
          switchToUser3(serviceInterface);
          cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 3);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_THREE);
          serviceInterface.updateRowWithId(APPNAME, db, DB_TABLE_ID, columns, cv, rowId.toString());
 
          table = serviceInterface.getRowsWithId(APPNAME, db, DB_TABLE_ID, columns, rowId
@@ -1269,7 +1272,7 @@ public class GroupsPermissionTest {
          assertEquals(DB_TABLE_ID, table.getTableId());
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
-         assertEquals(Long.valueOf(3), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_THREE), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_3, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1277,7 +1280,7 @@ public class GroupsPermissionTest {
          // verify user 2 cannot update
          switchToUser2(serviceInterface);
          cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 4);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_FOUR);
          serviceInterface.updateRowWithId(APPNAME, db, DB_TABLE_ID, columns, cv, rowId.toString());
          fail("Should have thrown an ActionNotAuthorizedException");
       }  catch (ActionNotAuthorizedException e) {
@@ -1384,7 +1387,7 @@ public class GroupsPermissionTest {
          // verify user 2 can change value
          switchToUser2(serviceInterface);
          cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 2);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_TWO);
          serviceInterface.updateRowWithId(APPNAME, db, DB_TABLE_ID, columns, cv, rowId.toString());
 
          // verify the change
@@ -1394,7 +1397,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -1469,7 +1472,7 @@ public class GroupsPermissionTest {
 
          // NOTE: until the sync state is changed no permissions are enforced
          ContentValues cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 2);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_TWO);
          cv.put(DataTableColumns.GROUP_MODIFY, TEST_GRP_2);
          cv.put(DataTableColumns.DEFAULT_ACCESS, RowFilterScope.Access.HIDDEN.name());
          cv.put(DataTableColumns.SYNC_STATE, SyncState.synced.name());
@@ -1485,7 +1488,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1506,7 +1509,7 @@ public class GroupsPermissionTest {
          //  switch the filter value to verify user 1 super user can still see row
          switchToUser1(serviceInterface);
          cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 3);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_THREE);
          cv.put(DataTableColumns.ROW_OWNER, "mailto:" + TEST_USER_2);
 
          assertEquals(rowId.toString(), row.getDataByKey
@@ -1520,7 +1523,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(3), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_THREE), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1538,7 +1541,7 @@ public class GroupsPermissionTest {
          row = table.getRowAtIndex(0);
 
          cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 4);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_FOUR);
          cv.put(DataTableColumns.GROUP_MODIFY, TEST_GRP_3);
 
          assertEquals(rowId.toString(), row.getDataByKey
@@ -1552,7 +1555,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(4), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_FOUR), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1564,7 +1567,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(4), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_FOUR), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1673,7 +1676,7 @@ public class GroupsPermissionTest {
          // verify user 2 can change value
          switchToUser2(serviceInterface);
          cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 2);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_TWO);
          serviceInterface.updateRowWithId(APPNAME, db, DB_TABLE_ID, columns, cv, rowId.toString());
 
          // verify the change
@@ -1683,7 +1686,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -1757,7 +1760,7 @@ public class GroupsPermissionTest {
 
          // NOTE: until the sync state is changed no permissions are enforced
          ContentValues cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 2);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_TWO);
          cv.put(DataTableColumns.GROUP_MODIFY, TEST_GRP_2);
          cv.put(DataTableColumns.DEFAULT_ACCESS, RowFilterScope.Access.HIDDEN.name());
          cv.put(DataTableColumns.SYNC_STATE, SyncState.synced.name());
@@ -1773,7 +1776,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(2),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1794,7 +1797,7 @@ public class GroupsPermissionTest {
          //  switch the filter value to verify user 1 super user can still see row
          switchToUser1(serviceInterface);
          cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 3);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_THREE);
          cv.put(DataTableColumns.ROW_OWNER, "mailto:" + TEST_USER_2);
 
          assertEquals(rowId.toString(), row.getDataByKey
@@ -1808,7 +1811,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(3), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_THREE), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1826,7 +1829,7 @@ public class GroupsPermissionTest {
          row = table.getRowAtIndex(0);
 
          cv = new ContentValues();
-         cv.put(COL_INTEGER_ID, 4);
+         cv.put(COL_INTEGER_ID, COL_INTEGER_VALUE_FOUR);
          cv.put(DataTableColumns.GROUP_MODIFY, TEST_GRP_3);
 
          assertEquals(rowId.toString(), row.getDataByKey
@@ -1840,7 +1843,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(4), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_FOUR), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1852,7 +1855,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(4), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(Long.valueOf(COL_INTEGER_VALUE_FOUR), row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/GroupsPermissionTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/GroupsPermissionTest.java
@@ -64,9 +64,9 @@ public class GroupsPermissionTest {
    private static final String TEST_STR_i = "TestStri";
    private static final int TEST_INT_i = 0;
    private static final double TEST_NUM_i = 0.1;
-   public static final int COL_INTEGER_VALUE_TWO = 2;
-   public static final int COL_INTEGER_VALUE_THREE = 3;
-   public static final int COL_INTEGER_VALUE_FOUR = 4;
+   public static final Long COL_INTEGER_VALUE_TWO = 2L;
+   public static final Long COL_INTEGER_VALUE_THREE = 3L;
+   public static final Long COL_INTEGER_VALUE_FOUR = 4L;
 
    private static final String TEST_GROUP_1 = "GROUP_ONE";
    private static final String TEST_USER_1 = "testUsr1@gmail.com";
@@ -605,7 +605,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_TWO,row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -731,7 +731,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_TWO,row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -861,7 +861,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_TWO, row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getRawStringByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getRawStringByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -990,7 +990,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_TWO,row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -1061,7 +1061,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_THREE),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_THREE,row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1087,7 +1087,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          TypedRow row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_FOUR), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_FOUR, row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_3, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1201,7 +1201,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_TWO,row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1250,7 +1250,7 @@ public class GroupsPermissionTest {
          assertEquals(DB_TABLE_ID, table.getTableId());
          assertEquals(1, table.getNumberOfRows());
          TypedRow row = table.getRowAtIndex(0);
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_TWO, row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1272,7 +1272,7 @@ public class GroupsPermissionTest {
          assertEquals(DB_TABLE_ID, table.getTableId());
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_THREE), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_THREE, row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_3, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1397,7 +1397,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_TWO,row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -1488,7 +1488,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_TWO,row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1523,7 +1523,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_THREE), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_THREE, row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1555,7 +1555,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_FOUR), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_FOUR, row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1567,7 +1567,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_FOUR), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_FOUR, row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1686,7 +1686,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_TWO,row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.SAVEPOINT_CREATOR));
 
@@ -1776,7 +1776,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_TWO),row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_TWO,row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1811,7 +1811,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_THREE), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_THREE, row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1843,7 +1843,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_FOUR), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_FOUR, row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));
@@ -1855,7 +1855,7 @@ public class GroupsPermissionTest {
          assertEquals(1, table.getNumberOfRows());
          row = table.getRowAtIndex(0);
 
-         assertEquals(Long.valueOf(COL_INTEGER_VALUE_FOUR), row.getDataByKey(COL_INTEGER_ID));
+         assertEquals(COL_INTEGER_VALUE_FOUR, row.getDataByKey(COL_INTEGER_ID));
          assertEquals("mailto:" + TEST_USER_2, row.getDataByKey(DataTableColumns.ROW_OWNER));
          assertEquals("mailto:" + TEST_USER_1, row.getDataByKey(DataTableColumns
              .SAVEPOINT_CREATOR));

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseBoolTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseBoolTest.java
@@ -95,24 +95,24 @@ public class OdkDatabaseBoolTest extends OdkDatabaseTestAbstractBase {
 
    private void verifyRowTestSet1(TypedRow row) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
-      assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) TEST_INT_1);
-      assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.TRUE);
+      assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(TEST_INT_1));
+      assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.valueOf(TEST_BOOL_1));
    }
 
    private void verifyRowTestSet2(TypedRow row) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_2);
       assertEquals(row.getDataByKey(COL_INTEGER_ID),
-              (long) TEST_INT_2);
+          Long.valueOf(TEST_INT_2));
       assertEquals(row.getDataByKey(COL_BOOL_ID),
-              Boolean.FALSE);
+          Boolean.valueOf(TEST_BOOL_2));
    }
 
    private void verifyRowTestSeti(TypedRow row, int i) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_i + i);
       assertEquals(row.getDataByKey(COL_INTEGER_ID),
-              (long) (TEST_INT_i + i));
+          Long.valueOf(TEST_INT_i + i));
       assertEquals(row.getDataByKey(COL_BOOL_ID),
-              (i % 2 != 0));
+          Boolean.valueOf((i%2 != 0)));
    }
 
    @Test
@@ -196,7 +196,7 @@ public class OdkDatabaseBoolTest extends OdkDatabaseTestAbstractBase {
          TypedRow row = table.getRowAtIndex(0);
 
          assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
-         assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) TEST_INT_1);
+         assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(TEST_INT_1));
          Boolean value = (Boolean) row.getDataByKey(COL_BOOL_ID);
           assertNull(value);
 
@@ -290,8 +290,8 @@ public class OdkDatabaseBoolTest extends OdkDatabaseTestAbstractBase {
 
             TypedRow row = new TypedRow(results.getRowAtIndex(0), columns);
             assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
-            assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) changeValue);
-            assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.TRUE);
+            assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(changeValue));
+            assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.valueOf(TEST_BOOL_1));
 
          } catch (ServicesAvailabilityException e) {
             e.printStackTrace();

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseBoolTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseBoolTest.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -53,7 +54,7 @@ public class OdkDatabaseBoolTest extends OdkDatabaseTestAbstractBase {
    }
 
    @NonNull private List<Column> createColumnList() {
-      List<Column> columns = new ArrayList<Column>();
+      List<Column> columns = new ArrayList<>();
 
       columns.add(new Column(COL_INTEGER_ID, "column Integer", "integer", null));
       columns.add(new Column(COL_BOOL_ID, "column Bool", "boolean", null));
@@ -94,29 +95,30 @@ public class OdkDatabaseBoolTest extends OdkDatabaseTestAbstractBase {
 
    private void verifyRowTestSet1(TypedRow row) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
-      assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(TEST_INT_1));
-      assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.valueOf(TEST_BOOL_1));
+      assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) TEST_INT_1);
+      assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.TRUE);
    }
 
    private void verifyRowTestSet2(TypedRow row) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_2);
       assertEquals(row.getDataByKey(COL_INTEGER_ID),
-          Long.valueOf(TEST_INT_2));
+              (long) TEST_INT_2);
       assertEquals(row.getDataByKey(COL_BOOL_ID),
-          Boolean.valueOf(TEST_BOOL_2));
+              Boolean.FALSE);
    }
 
    private void verifyRowTestSeti(TypedRow row, int i) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_i + i);
       assertEquals(row.getDataByKey(COL_INTEGER_ID),
-          Long.valueOf(TEST_INT_i + i));
+              (long) (TEST_INT_i + i));
       assertEquals(row.getDataByKey(COL_BOOL_ID),
-          Boolean.valueOf((i%2 != 0)));
+              (i % 2 != 0));
    }
 
    @Test
    public void testBinding() {
       UserDbInterfaceImpl serviceInterface = bindToDbService();
+      assertNotNull(serviceInterface);
       assertNotNull( "bind did not succeed",
           ((InternalUserDbInterfaceAidlWrapperImpl) serviceInterface.getInternalUserDbInterface()).getDbInterface());
    }
@@ -129,7 +131,8 @@ public class OdkDatabaseBoolTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbInsertSingleRowIntoTable: " + db.getDatabaseHandle());
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, colList);
 
@@ -169,6 +172,7 @@ public class OdkDatabaseBoolTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+         assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbInsertSingleRowIntoTable: " + db.getDatabaseHandle());
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, colList);
@@ -192,9 +196,9 @@ public class OdkDatabaseBoolTest extends OdkDatabaseTestAbstractBase {
          TypedRow row = table.getRowAtIndex(0);
 
          assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
-         assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(TEST_INT_1));
+         assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) TEST_INT_1);
          Boolean value = (Boolean) row.getDataByKey(COL_BOOL_ID);
-         assertEquals(value, null);
+          assertNull(value);
 
          // clean up
          serviceInterface.deleteTableAndAllData(APPNAME, db, DB_TABLE_ID);
@@ -214,6 +218,7 @@ public class OdkDatabaseBoolTest extends OdkDatabaseTestAbstractBase {
       try {
          ColumnList columnListObj = new ColumnList(createColumnList());
 
+         assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbInsertTwoRowsIntoLocalOnlyTable: " + db.getDatabaseHandle());
          // TODO: why do we have a dbHandle and APPNAME?
@@ -253,6 +258,7 @@ public class OdkDatabaseBoolTest extends OdkDatabaseTestAbstractBase {
          DbHandle db = null;
          try {
             ColumnList columnListObj = new ColumnList(createColumnList());
+            assertNotNull(serviceInterface);
             db = serviceInterface.openDatabase(APPNAME);
             Log.i("openDatabase", "testDbUpdateSingleValue: " + db.getDatabaseHandle());
             OrderedColumns columns = serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, columnListObj);
@@ -284,8 +290,8 @@ public class OdkDatabaseBoolTest extends OdkDatabaseTestAbstractBase {
 
             TypedRow row = new TypedRow(results.getRowAtIndex(0), columns);
             assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
-            assertEquals(row.getDataByKey(COL_INTEGER_ID), Long.valueOf(changeValue));
-            assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.valueOf(TEST_BOOL_1));
+            assertEquals(row.getDataByKey(COL_INTEGER_ID), (long) changeValue);
+            assertEquals(row.getDataByKey(COL_BOOL_ID), Boolean.TRUE);
 
          } catch (ServicesAvailabilityException e) {
             e.printStackTrace();

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseServiceImplTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseServiceImplTest.java
@@ -3,7 +3,7 @@ package org.opendatakit.database.service;
 import android.content.ContentValues;
 import android.database.Cursor;
 
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -47,6 +47,7 @@ import java.util.Map;
 import static android.text.TextUtils.join;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -84,9 +85,10 @@ public class OdkDatabaseServiceImplTest
    protected void setUpBefore() {
       try {
          serviceInterface = bindToDbService();
-         dbHandle = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          dbHandle = serviceInterface.openDatabase(APPNAME);
 
-         props = CommonToolProperties.get(InstrumentationRegistry.getTargetContext(), APPNAME);
+         props = CommonToolProperties.get(ApplicationProvider.getApplicationContext(), APPNAME);
          props.clearSettings();
       } catch (Exception e) {
          e.printStackTrace();
@@ -188,7 +190,8 @@ public class OdkDatabaseServiceImplTest
          for (Row row : rows) {
             assertEquals(row.getRawStringByKey(COLUMN_ID1), "ayy lmao");
             Long value = row.getDataType(COLUMN_ID2, Long.class);
-            assertTrue(value.intValue() == 3);
+             assertNotNull(value);
+             assertEquals(3, value.intValue());
          }
          assertColType("L_" + TABLE_LOCAL, COLUMN_ID2, "INTEGER");
          assertColType("L_" + TABLE_LOCAL, COLUMN_ID3, "REAL");
@@ -272,7 +275,8 @@ public class OdkDatabaseServiceImplTest
          if (row.getRawStringByKey(COLUMN_ID1).equals(id)) {
             assertEquals(row.getRawStringByKey(COLUMN_ID1), id);
             Long value = row.getDataType(COLUMN_ID2, Long.class);
-            assertTrue(value.intValue() == intValue);
+             assertNotNull(value);
+             assertEquals(value.intValue(), intValue);
             Double val3 = row.getDataType(COLUMN_ID3, Double.class);
             assertEquals(val3, doubleValue, delta);
          }
@@ -1198,12 +1202,12 @@ public class OdkDatabaseServiceImplTest
    @Test public void testGetAllTableIds() {
       try {
          serviceInterface.createOrOpenTableWithColumns(APPNAME, dbHandle, "breathcounter",
-             new ColumnList(new ArrayList<Column>()));
+             new ColumnList(new ArrayList<>()));
          serviceInterface.createOrOpenTableWithColumns(APPNAME, dbHandle, "fields",
-             new ColumnList(new ArrayList<Column>()));
+             new ColumnList(new ArrayList<>()));
 
          List<String> tables = serviceInterface.getAllTableIds(APPNAME, dbHandle);
-         assertTrue(tables.size() == 2);
+          assertEquals(2, tables.size());
          // Test that it returns list in sorted order
          assertEquals(tables.get(0), "breathcounter");
          assertEquals(tables.get(1), "fields");
@@ -1401,7 +1405,7 @@ public class OdkDatabaseServiceImplTest
       }
    }
 
-   @Test public void testGetTableHealthStatus() throws Exception {
+   @Test public void testGetTableHealthStatus() {
       try {
          //_savepoint_type is null -> + 1 checkpoint
          //_conflict_type not is null -> + 1 conflict
@@ -1486,7 +1490,7 @@ public class OdkDatabaseServiceImplTest
       return c.getString(c.getColumnIndexOrThrow(col));
    }
 
-   private void assertColType(String table, String column, String expectedType) throws Exception {
+   private void assertColType(String table, String column, String expectedType) {
       OdkConnectionInterface db = OdkConnectionFactorySingleton.getOdkConnectionFactoryInterface()
           .getConnection(APPNAME, dbHandle);
 
@@ -1505,7 +1509,7 @@ public class OdkDatabaseServiceImplTest
       return c.getDouble(c.getColumnIndexOrThrow(col));
    }
 
-   private static int getInt(Cursor c, String col) throws Exception {
+   private static int getInt(Cursor c, String col) {
       return c.getInt(c.getColumnIndexOrThrow(col));
    }
 
@@ -1595,7 +1599,7 @@ public class OdkDatabaseServiceImplTest
       c.close();
    }
 
-   private void thSetRevid(String revId) throws Exception {
+   private void thSetRevid(String revId) {
       String cId = TableDefinitionsColumns.TABLE_ID;
       String cSchema = TableDefinitionsColumns.SCHEMA_ETAG;
       String cData = TableDefinitionsColumns.LAST_DATA_ETAG;
@@ -1612,7 +1616,7 @@ public class OdkDatabaseServiceImplTest
           new String[] { TEA_HOUSES_TBL_NAME, "schema etag", "data etag", "time", revId });
    }
 
-   private void thSet(String id, String col, Object val) throws Exception {
+   private void thSet(String id, String col, Object val) {
       OdkConnectionInterface db = OdkConnectionFactorySingleton.getOdkConnectionFactoryInterface()
           .getConnection(APPNAME, dbHandle);
       db.rawQuery("UPDATE Tea_houses SET " + col + " = " + (val == null ? "NULL" : "?") + " "
@@ -1644,7 +1648,7 @@ public class OdkDatabaseServiceImplTest
    }
 
    private void createTeaHouses() throws Exception {
-      List<Column> columns = new ArrayList<Column>();
+      List<Column> columns = new ArrayList<>();
 
       columns.add(new Column("Customers", "Customers", "integer", null));
       columns.add(new Column("Date_Opened", "Date_Opened", ElementDataType.string.name(), null));
@@ -1680,7 +1684,7 @@ public class OdkDatabaseServiceImplTest
           .deleteTableMetadata(APPNAME, dbHandle, TEA_HOUSES_TBL_NAME, null, null, null);
    }
 
-   private void setProp(PropertiesSingleton props, String a, String b) throws Exception {
+   private void setProp(PropertiesSingleton props, String a, String b) {
       Map<String, String> m = new HashMap<>();
       m.put(a, b);
       props.setProperties(m);

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseServiceImplTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseServiceImplTest.java
@@ -63,6 +63,8 @@ public class OdkDatabaseServiceImplTest
    public static final String TABLE_NAME2 = "tb2";
    public static final String TABLE_LOCAL = "tablelocal";
    public static final String TEA_HOUSES_TBL_NAME = "tea_houses";
+   public static final String COLUMN_ID1_VALUE_ONE = "ayy lmao";
+   public static final int COLUMN_ID2_VALUE_ONE = 3;
 
    public static final String CHOICE_LIST_JSON = "[{\"choice_list_name\":\"climate_types\","
        + "\"data_value\":\"moderate\",\"display\":{\"title\":{\"text\":{\"default\":\"Moderate\",\"es\":\"Moderate\"}}},\"_row_num\":41},{\"choice_list_name\":\"climate_types\",\"data_value\":\"temperate\",\"display\":{\"title\":{\"text\":{\"default\":\"Temperate\",\"es\":\"Templado\"}}},\"_row_num\":42},{\"choice_list_name\":\"climate_types\",\"data_value\":\"hot\",\"display\":{\"title\":{\"text\":{\"default\":\"Hot\",\"es\":\"Caliente\"}}},\"_row_num\":43}]";
@@ -176,8 +178,8 @@ public class OdkDatabaseServiceImplTest
              getLocalTableColumnList());
 
          ContentValues cv = new ContentValues();
-         cv.put(COLUMN_ID1, "ayy lmao");
-         cv.put(COLUMN_ID2, 3);
+         cv.put(COLUMN_ID1, COLUMN_ID1_VALUE_ONE);
+         cv.put(COLUMN_ID2, COLUMN_ID2_VALUE_ONE);
 
          serviceInterface.insertLocalOnlyRow(APPNAME, dbHandle, TABLE_LOCAL, cv);
 
@@ -188,10 +190,10 @@ public class OdkDatabaseServiceImplTest
          List<Row> rows = baseTable.getRows();
          assertEquals(rows.size(), 1);
          for (Row row : rows) {
-            assertEquals(row.getRawStringByKey(COLUMN_ID1), "ayy lmao");
+            assertEquals(row.getRawStringByKey(COLUMN_ID1), COLUMN_ID1_VALUE_ONE);
             Long value = row.getDataType(COLUMN_ID2, Long.class);
              assertNotNull(value);
-             assertEquals(3, value.intValue());
+             assertEquals(COLUMN_ID2_VALUE_ONE, value.intValue());
          }
          assertColType("L_" + TABLE_LOCAL, COLUMN_ID2, "INTEGER");
          assertColType("L_" + TABLE_LOCAL, COLUMN_ID3, "REAL");

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseServiceTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseServiceTest.java
@@ -154,33 +154,33 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
    private void verifyRowTestSet1(TypedRow row) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
       assertEquals(row.getDataByKey(COL_INTEGER_ID),
-              (long) TEST_INT_1);
+          Long.valueOf(TEST_INT_1));
       assertEquals(row.getDataByKey(COL_NUMBER_ID),
-              TEST_NUM_1);
+          Double.valueOf(TEST_NUM_1));
    }
 
    private void verifyRowTestSet2(TypedRow row) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_2);
       assertEquals(row.getDataByKey(COL_INTEGER_ID),
-              (long) TEST_INT_2);
+          Long.valueOf(TEST_INT_2));
       assertEquals(row.getDataByKey(COL_NUMBER_ID),
-              TEST_NUM_2);
+          Double.valueOf(TEST_NUM_2));
    }
 
    private void verifyRowTestSeti(TypedRow row, int i) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_i + i);
       assertEquals(row.getDataByKey(COL_INTEGER_ID),
-              (long) (TEST_INT_i + i));
+          Long.valueOf(TEST_INT_i + i));
       assertEquals(row.getDataByKey(COL_NUMBER_ID),
-              TEST_NUM_i + i);
+          Double.valueOf(TEST_NUM_i + i));
    }
 
    private void veriftyRowTestSetManyColumns(TypedRow row, int i) {
       for (int j = 0; j < MANY_COL_NUM_COLUMNS; j++) {
          assertEquals(row.getDataByKey(MANY_COL_STRING_ID + j), "STR_" + j + "_" + i);
-         assertEquals(row.getDataByKey(MANY_COL_INTEGER_ID + j), (long) (i + j));
-         assertEquals(row.getDataByKey(MANY_COL_NUMBER_ID + j), (double) (i * j));
-         assertEquals(row.getDataByKey(MANY_COL_BOOL_ID + j), ((i + j) % 2) == 1);
+         assertEquals(row.getDataByKey(MANY_COL_INTEGER_ID + j), Long.valueOf(i + j));
+         assertEquals(row.getDataByKey(MANY_COL_NUMBER_ID + j), Double.valueOf(i * j));
+         assertEquals(row.getDataByKey(MANY_COL_BOOL_ID + j), Boolean.valueOf(((i+j)%2)==1));
          assertEquals(row.getDataByKey(MANY_COL_DATE_ID + j), dateString);
       }
    }
@@ -796,9 +796,9 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
 
          assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
          assertEquals(row.getDataByKey(COL_INTEGER_ID),
-                 (long) changeValue);
+             Long.valueOf(changeValue));
          assertEquals(row.getDataByKey(COL_NUMBER_ID),
-                 TEST_NUM_1);
+             Double.valueOf(TEST_NUM_1));
 
          // clean up
          serviceInterface.deleteTableAndAllData(APPNAME, db, DB_TABLE_ID);

--- a/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseServiceTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/database/service/OdkDatabaseServiceTest.java
@@ -76,7 +76,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
    }
 
    @NonNull private List<Column> createColumnList() {
-      List<Column> columns = new ArrayList<Column>();
+      List<Column> columns = new ArrayList<>();
 
       columns.add(new Column(COL_STRING_ID, "column String", "string", null));
       columns.add(new Column(COL_INTEGER_ID, "column Integer", "integer", null));
@@ -154,33 +154,33 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
    private void verifyRowTestSet1(TypedRow row) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
       assertEquals(row.getDataByKey(COL_INTEGER_ID),
-          Long.valueOf(TEST_INT_1));
+              (long) TEST_INT_1);
       assertEquals(row.getDataByKey(COL_NUMBER_ID),
-          Double.valueOf(TEST_NUM_1));
+              TEST_NUM_1);
    }
 
    private void verifyRowTestSet2(TypedRow row) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_2);
       assertEquals(row.getDataByKey(COL_INTEGER_ID),
-          Long.valueOf(TEST_INT_2));
+              (long) TEST_INT_2);
       assertEquals(row.getDataByKey(COL_NUMBER_ID),
-          Double.valueOf(TEST_NUM_2));
+              TEST_NUM_2);
    }
 
    private void verifyRowTestSeti(TypedRow row, int i) {
       assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_i + i);
       assertEquals(row.getDataByKey(COL_INTEGER_ID),
-          Long.valueOf(TEST_INT_i + i));
+              (long) (TEST_INT_i + i));
       assertEquals(row.getDataByKey(COL_NUMBER_ID),
-          Double.valueOf(TEST_NUM_i + i));
+              TEST_NUM_i + i);
    }
 
    private void veriftyRowTestSetManyColumns(TypedRow row, int i) {
       for (int j = 0; j < MANY_COL_NUM_COLUMNS; j++) {
          assertEquals(row.getDataByKey(MANY_COL_STRING_ID + j), "STR_" + j + "_" + i);
-         assertEquals(row.getDataByKey(MANY_COL_INTEGER_ID + j), Long.valueOf(i + j));
-         assertEquals(row.getDataByKey(MANY_COL_NUMBER_ID + j), Double.valueOf(i * j));
-         assertEquals(row.getDataByKey(MANY_COL_BOOL_ID + j), Boolean.valueOf(((i+j)%2)==1));
+         assertEquals(row.getDataByKey(MANY_COL_INTEGER_ID + j), (long) (i + j));
+         assertEquals(row.getDataByKey(MANY_COL_NUMBER_ID + j), (double) (i * j));
+         assertEquals(row.getDataByKey(MANY_COL_BOOL_ID + j), ((i + j) % 2) == 1);
          assertEquals(row.getDataByKey(MANY_COL_DATE_ID + j), dateString);
       }
    }
@@ -195,7 +195,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
    @Test
    public void testBinding() {
       UserDbInterfaceImpl serviceInterface = bindToDbService();
-      assertNotNull( "bind did not succeed",
+       assertNotNull(serviceInterface);
+       assertNotNull( "bind did not succeed",
           ((InternalUserDbInterfaceAidlWrapperImpl) serviceInterface.getInternalUserDbInterface()).getDbInterface());
       // TODO: database check function?
 
@@ -208,7 +209,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
       try {
          ColumnList columnList = new ColumnList(createColumnList());
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbCreateNDeleteTable: " + db.getDatabaseHandle());
          // TODO: why do we have a dbHandle and APPNAME?
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, columnList);
@@ -216,7 +218,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<String> tableIds = serviceInterface.getAllTableIds(APPNAME, db);
 
          // verify single table exists
-         assertTrue(tableIds.size() == 1);
+          assertEquals(1, tableIds.size());
          assertTrue(tableIds.contains(DB_TABLE_ID));
 
          serviceInterface.deleteTableAndAllData(APPNAME, db, DB_TABLE_ID);
@@ -236,14 +238,15 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
       try {
          ColumnList columnList = new ColumnList(createColumnList());
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbCreateNDeleteTableWTransactions: " + db.getDatabaseHandle());
          // TODO: why do we have a dbHandle and APPNAME?
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, columnList);
 
          List<String> tableIds = serviceInterface.getAllTableIds(APPNAME, db);
          // verify single table exists
-         assertTrue(tableIds.size() == 1);
+          assertEquals(1, tableIds.size());
          assertTrue(tableIds.contains(DB_TABLE_ID));
 
          serviceInterface.deleteTableAndAllData(APPNAME, db, DB_TABLE_ID);
@@ -265,7 +268,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbInsertSingleRowIntoTable: " + db.getDatabaseHandle());
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, colList);
 
@@ -308,7 +312,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          db = serviceInterface.openDatabase(APPNAME);
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, colList);
 
          OrderedColumns columns = new OrderedColumns(APPNAME, DB_TABLE_ID, columnList);
@@ -324,9 +329,10 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          // expected
          assertTrue("Got what we expected " + e.toString(), true);
       } catch (Exception e) {
-         assertTrue("Unexpected " + e.toString(), false);
+          fail("Unexpected " + e.toString());
       } finally {
          // clean up
+          assertNotNull(serviceInterface);
          serviceInterface.deleteTableAndAllData(APPNAME, db, DB_TABLE_ID);
 
          serviceInterface.closeDatabase(APPNAME, db);
@@ -342,6 +348,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+          assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, colList);
 
@@ -382,7 +389,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase",
              "testDbInsertSingleRowIntoTableWTwoTransactions: " + db.getDatabaseHandle());
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, colList);
@@ -423,6 +431,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+          assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbInsertTwoRowsIntoTable: " + db.getDatabaseHandle());
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, colList);
@@ -468,6 +477,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+          assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
 
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, colList);
@@ -512,6 +522,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+          assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase",
              "testDbInsertTwoRowsIntoTableWTwoTransactions: " + db.getDatabaseHandle());
@@ -559,6 +570,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+          assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbQueryWNoParams: " + db.getDatabaseHandle());
          serviceInterface.createOrOpenTableWithColumns(APPNAME, db, DB_TABLE_ID, colList);
@@ -638,6 +650,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+          assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbUpdateAllValues: " + db.getDatabaseHandle());
 
@@ -688,6 +701,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+          assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbUpdateAllValuesWTransactions: " + db.getDatabaseHandle());
 
@@ -739,6 +753,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+          assertNotNull(serviceInterface);
          db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbUpdateSingleValue: " + db.getDatabaseHandle());
 
@@ -760,7 +775,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          TypedRow row = table.getRowAtIndex(0);
          verifyRowTestSet1(table.getRowAtIndex(0));
 
-         List<Column> singleColumnArray = new ArrayList<Column>();
+         List<Column> singleColumnArray = new ArrayList<>();
          singleColumnArray.add(new Column(COL_INTEGER_ID, "column Integer", "integer", null));
          OrderedColumns singleColumn = new OrderedColumns(APPNAME, DB_TABLE_ID, singleColumnArray);
 
@@ -781,9 +796,9 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
 
          assertEquals(row.getDataByKey(COL_STRING_ID), TEST_STR_1);
          assertEquals(row.getDataByKey(COL_INTEGER_ID),
-             Long.valueOf(changeValue));
+                 (long) changeValue);
          assertEquals(row.getDataByKey(COL_NUMBER_ID),
-             Double.valueOf(TEST_NUM_1));
+                 TEST_NUM_1);
 
          // clean up
          serviceInterface.deleteTableAndAllData(APPNAME, db, DB_TABLE_ID);
@@ -817,6 +832,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+          assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbInsertNDeleteSingleRowIntoTable: " + db.getDatabaseHandle());
 
@@ -869,6 +885,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+          assertNotNull(serviceInterface);
          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbCreateNDeleteLargeTable: " + db.getDatabaseHandle());
 
@@ -949,6 +966,7 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createManyColumnList();
          ColumnList colList = new ColumnList(columnList);
 
+          assertNotNull(serviceInterface);
          db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase",
              "testDbCreateNVerifyNDeleteLargeTableManyColumns: " + db.getDatabaseHandle());
@@ -1050,11 +1068,13 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          OrderedColumns columns = new OrderedColumns(APPNAME, DB_TABLE_ID, columnList);
          UUID rowId = UUID.randomUUID();
 
+          assertNotNull(serviceInterface1);
          DbHandle db1 = serviceInterface1.openDatabase(APPNAME);
          Log.i("openDatabase",
              "testDbUpdateWTwoServiceConnections db1: " + db1.getDatabaseHandle());
 
-         DbHandle db2 = serviceInterface2.openDatabase(APPNAME);
+          assertNotNull(serviceInterface2);
+          DbHandle db2 = serviceInterface2.openDatabase(APPNAME);
          Log.i("openDatabase",
              "testDbUpdateWTwoServiceConnections db2: " + db2.getDatabaseHandle());
 
@@ -1124,7 +1144,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbLimitNoOffset: " + db.getDatabaseHandle());
          OrderedColumns columns = serviceInterface.createOrOpenTableWithColumns(APPNAME, db,
              DB_TABLE_ID, colList);
@@ -1169,7 +1190,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbLimitNoOffsetArbitraryQuery: " + db.getDatabaseHandle());
          OrderedColumns columns = serviceInterface.createOrOpenTableWithColumns(APPNAME, db,
              DB_TABLE_ID, colList);
@@ -1209,7 +1231,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbLimitOver: " + db.getDatabaseHandle());
          OrderedColumns columns = serviceInterface.createOrOpenTableWithColumns(APPNAME, db,
              DB_TABLE_ID, colList);
@@ -1253,7 +1276,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbLimitOverArbitraryQuery: " + db.getDatabaseHandle());
          OrderedColumns columns = serviceInterface.createOrOpenTableWithColumns(APPNAME, db,
              DB_TABLE_ID, colList);
@@ -1294,7 +1318,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbOffsetNoLimit: " + db.getDatabaseHandle());
          OrderedColumns columns = serviceInterface.createOrOpenTableWithColumns(APPNAME, db,
              DB_TABLE_ID, colList);
@@ -1339,7 +1364,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbOffsetNoLimitArbitraryQuery: " + db.getDatabaseHandle());
          OrderedColumns columns = serviceInterface.createOrOpenTableWithColumns(APPNAME, db,
              DB_TABLE_ID, colList);
@@ -1380,7 +1406,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbLimitWithOffset: " + db.getDatabaseHandle());
          OrderedColumns columns = serviceInterface.createOrOpenTableWithColumns(APPNAME, db,
              DB_TABLE_ID, colList);
@@ -1424,7 +1451,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbLimitWithOffsetArbitraryQuery: " + db.getDatabaseHandle());
          OrderedColumns columns = serviceInterface.createOrOpenTableWithColumns(APPNAME, db,
              DB_TABLE_ID, colList);
@@ -1465,7 +1493,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbInsertSingleRowIntoTable: " + db.getDatabaseHandle());
          OrderedColumns columns = serviceInterface.createOrOpenTableWithColumns(APPNAME, db,
              DB_TABLE_ID, colList);
@@ -1517,7 +1546,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbInsertSingleRowIntoTable: " + db.getDatabaseHandle());
          OrderedColumns columns = serviceInterface.createOrOpenTableWithColumns(APPNAME, db,
              DB_TABLE_ID, colList);
@@ -1563,7 +1593,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbInsertSingleRowIntoTable: " + db.getDatabaseHandle());
          OrderedColumns columns = serviceInterface.createOrOpenTableWithColumns(APPNAME, db,
              DB_TABLE_ID, colList);
@@ -1615,7 +1646,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
          List<Column> columnList = createColumnList();
          ColumnList colList = new ColumnList(columnList);
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbInsertSingleRowIntoTable: " + db.getDatabaseHandle());
          OrderedColumns columns = serviceInterface.createOrOpenTableWithColumns(APPNAME, db,
              DB_TABLE_ID, colList);
@@ -1667,7 +1699,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
       try {
          ColumnList columnListObj = new ColumnList(createColumnList());
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbCreateNDeleteLocalOnlyTable: " + db.getDatabaseHandle());
          // TODO: why do we have a dbHandle and APPNAME?
          OrderedColumns columns = serviceInterface
@@ -1693,7 +1726,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
       try {
          ColumnList columnListObj = new ColumnList(createColumnList());
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          Log.i("openDatabase", "testDbCreateNDeleteLocalOnlyTable: " + db.getDatabaseHandle());
          // TODO: why do we have a dbHandle and APPNAME?
          OrderedColumns columns = serviceInterface
@@ -1734,7 +1768,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
       try {
          ColumnList columnListObj = new ColumnList(createColumnList());
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
 
          OrderedColumns columns = serviceInterface
              .createLocalOnlyTableWithColumns(APPNAME, db, DB_TABLE_ID, columnListObj);
@@ -1773,7 +1808,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
       try {
          ColumnList columnListObj = new ColumnList(createColumnList());
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
 
          OrderedColumns columns = serviceInterface
              .createLocalOnlyTableWithColumns(APPNAME, db, DB_TABLE_ID, columnListObj);
@@ -1826,7 +1862,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
       try {
          ColumnList columnListObj = new ColumnList(createColumnList());
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
 
          OrderedColumns columns = serviceInterface
              .createLocalOnlyTableWithColumns(APPNAME, db, DB_TABLE_ID, columnListObj);
@@ -1886,7 +1923,8 @@ public class OdkDatabaseServiceTest extends OdkDatabaseTestAbstractBase {
       try {
          ColumnList columnListObj = new ColumnList(createColumnList());
 
-         DbHandle db = serviceInterface.openDatabase(APPNAME);
+          assertNotNull(serviceInterface);
+          DbHandle db = serviceInterface.openDatabase(APPNAME);
          OrderedColumns columns = serviceInterface
              .createLocalOnlyTableWithColumns(APPNAME, db, DB_TABLE_ID, columnListObj);
 


### PR DESCRIPTION
This PR:
- Replace deprecated InstrumentationRegistry.getContext() with ApplicationProvider.getApplicationContext()
- Handle null pointer exception 
- Simplify assertions
- Clean up code
