### PR TITLE
Fix various Activity UI tests

### DIFF
--- a/services_app/src/androidTest/java/org/opendatakit/activites/LoginActivity/GeneralStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/LoginActivity/GeneralStateTest.java
@@ -19,6 +19,7 @@ import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.matcher.IntentMatchers;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.platform.app.InstrumentationRegistry;
 
@@ -50,8 +51,7 @@ public class GeneralStateTest {
         Intent intent = new Intent(getContext(), LoginActivity.class);
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
-
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = activity.getProps();
             assertThat(props).isNotNull();

--- a/services_app/src/androidTest/java/org/opendatakit/activites/LoginActivity/LoggedOutStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/LoginActivity/LoggedOutStateTest.java
@@ -14,6 +14,7 @@ import android.content.Intent;
 
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.action.ViewActions;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.platform.app.InstrumentationRegistry;
 
@@ -43,7 +44,7 @@ public class LoggedOutStateTest {
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
 
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = activity.getProps();
             assertThat(props).isNotNull();

--- a/services_app/src/androidTest/java/org/opendatakit/activites/MainActivity/AnonymousStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/MainActivity/AnonymousStateTest.java
@@ -16,6 +16,7 @@ import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.matcher.IntentMatchers;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.platform.app.InstrumentationRegistry;
 
@@ -50,7 +51,7 @@ public class AnonymousStateTest {
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
 
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = CommonToolProperties.get(activity, activity.getAppName());
             assertThat(props).isNotNull();

--- a/services_app/src/androidTest/java/org/opendatakit/activites/MainActivity/AuthenticatedUserStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/MainActivity/AuthenticatedUserStateTest.java
@@ -17,6 +17,7 @@ import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.matcher.IntentMatchers;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.platform.app.InstrumentationRegistry;
 
@@ -55,7 +56,7 @@ public class AuthenticatedUserStateTest {
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
 
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = CommonToolProperties.get(activity, activity.getAppName());
             assertThat(props).isNotNull();

--- a/services_app/src/androidTest/java/org/opendatakit/activites/MainActivity/GeneralStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/MainActivity/GeneralStateTest.java
@@ -17,6 +17,7 @@ import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.matcher.IntentMatchers;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.After;
@@ -48,7 +49,7 @@ public class GeneralStateTest {
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
 
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = CommonToolProperties.get(activity, activity.getAppName());
             assertThat(props).isNotNull();

--- a/services_app/src/androidTest/java/org/opendatakit/activites/MainActivity/GeneralStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/MainActivity/GeneralStateTest.java
@@ -72,7 +72,7 @@ public class GeneralStateTest {
             activity.recreate();
         });
 
-        onView(withId(android.R.id.button1)).perform(ViewActions.click());
+        onView(withId(android.R.id.button1)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
 
         onView(withId(R.id.inputServerUrl)).check(matches(isDisplayed()));
         onView(withId(R.id.inputTextServerUrl)).check(matches(withText(TEST_SERVER_URL)));

--- a/services_app/src/androidTest/java/org/opendatakit/activites/MainActivity/LoggedOutStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/MainActivity/LoggedOutStateTest.java
@@ -15,6 +15,7 @@ import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.matcher.IntentMatchers;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.platform.app.InstrumentationRegistry;
 
@@ -43,7 +44,7 @@ public class LoggedOutStateTest {
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
 
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = CommonToolProperties.get(activity, activity.getAppName());
             assertThat(props).isNotNull();

--- a/services_app/src/androidTest/java/org/opendatakit/activites/SyncActivity/AnonymousStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/SyncActivity/AnonymousStateTest.java
@@ -60,7 +60,7 @@ public class AnonymousStateTest {
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
 
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = activity.getProps();
             assertThat(props).isNotNull();

--- a/services_app/src/androidTest/java/org/opendatakit/activites/SyncActivity/AuthenticatedUserStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/SyncActivity/AuthenticatedUserStateTest.java
@@ -64,7 +64,7 @@ public class AuthenticatedUserStateTest {
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
 
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = activity.getProps();
             assertThat(props).isNotNull();

--- a/services_app/src/androidTest/java/org/opendatakit/activites/SyncActivity/GeneralStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/SyncActivity/GeneralStateTest.java
@@ -17,6 +17,7 @@ import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.matcher.IntentMatchers;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.After;
@@ -48,7 +49,7 @@ public class GeneralStateTest {
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
 
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = activity.getProps();
             assertThat(props).isNotNull();

--- a/services_app/src/androidTest/java/org/opendatakit/activites/SyncActivity/LoggedOutStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/SyncActivity/LoggedOutStateTest.java
@@ -19,6 +19,7 @@ import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.matcher.IntentMatchers;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.platform.app.InstrumentationRegistry;
 
@@ -50,7 +51,7 @@ public class LoggedOutStateTest {
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
 
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = activity.getProps();
             assertThat(props).isNotNull();

--- a/services_app/src/androidTest/java/org/opendatakit/activites/VerifyServerSettingsActivity/AnonymousStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/VerifyServerSettingsActivity/AnonymousStateTest.java
@@ -16,6 +16,7 @@ import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.matcher.IntentMatchers;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.platform.app.InstrumentationRegistry;
 
@@ -49,7 +50,7 @@ public class AnonymousStateTest {
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
 
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = activity.getProps();
             assertThat(props).isNotNull();

--- a/services_app/src/androidTest/java/org/opendatakit/activites/VerifyServerSettingsActivity/AuthenticatedUserStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/VerifyServerSettingsActivity/AuthenticatedUserStateTest.java
@@ -17,6 +17,7 @@ import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.matcher.IntentMatchers;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.platform.app.InstrumentationRegistry;
 
@@ -56,7 +57,7 @@ public class AuthenticatedUserStateTest {
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
 
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = activity.getProps();
             assertThat(props).isNotNull();

--- a/services_app/src/androidTest/java/org/opendatakit/activites/VerifyServerSettingsActivity/GeneralStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/VerifyServerSettingsActivity/GeneralStateTest.java
@@ -17,6 +17,7 @@ import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.matcher.IntentMatchers;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.After;
@@ -47,7 +48,7 @@ public class GeneralStateTest {
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
 
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = activity.getProps();
             assertThat(props).isNotNull();

--- a/services_app/src/androidTest/java/org/opendatakit/activites/VerifyServerSettingsActivity/GeneralStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/VerifyServerSettingsActivity/GeneralStateTest.java
@@ -71,7 +71,7 @@ public class GeneralStateTest {
             activity.recreate();
         });
 
-        onView(withId(android.R.id.button1)).perform(ViewActions.click());
+        onView(withId(android.R.id.button1)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
 
         onView(withId(R.id.inputServerUrl)).check(matches(isDisplayed()));
         onView(withId(R.id.inputTextServerUrl)).check(matches(withText(TEST_SERVER_URL)));

--- a/services_app/src/androidTest/java/org/opendatakit/activites/VerifyServerSettingsActivity/LoggedOutStateTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/activites/VerifyServerSettingsActivity/LoggedOutStateTest.java
@@ -15,6 +15,7 @@ import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.matcher.IntentMatchers;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.platform.app.InstrumentationRegistry;
 
@@ -46,7 +47,7 @@ public class LoggedOutStateTest {
         intent.putExtra(IntentConsts.INTENT_KEY_APP_NAME, APP_NAME);
         activityScenario = ActivityScenario.launch(intent);
 
-        onView(withId(android.R.id.button2)).perform(ViewActions.click());
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click());
         activityScenario.onActivity(activity -> {
             PropertiesSingleton props = activity.getProps();
             assertThat(props).isNotNull();


### PR DESCRIPTION
Almost 50% of the existing tests in `org.opendatakit.activities` package were failing due to Espresso's **RootViewWithoutFocusException** during the test setUp phase:
```
androidx.test.espresso.base.RootViewPicker$RootViewWithoutFocusException: Waited for the root of the view hierarchy to have window focus and not request layout for 10 seconds. If you specified a non 

default root matcher, it may be picking a root that never takes focus.
Root:
Root{application-window-token=android.view.ViewRootImpl$W@1aaa91d, window-token=android.view.ViewRootImpl$W@1aaa91d, has-window-focus=false, layout-params-type=1, layout-params-string={(0,0)(fillxfill) ty=BASE_APPLICATION wanim=0x10302fe 
```

This was happening since Espresso was using the default root to find the view but it kept failing randomly since the view was inside AlertDialog.

### Before
![41/82 tests passing](https://user-images.githubusercontent.com/57134307/162074112-ef5d2a5e-2a56-44da-8477-b4f491d0243e.png)

### After
![82/82 tests passing](https://user-images.githubusercontent.com/57134307/162074266-c2ce1e9e-b4e5-4c0b-bf28-e8ee057b8aa0.png)