### PR TITLE
 Unit Test suites for ViewModels

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=4096m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.enableJetifier=true
+android.jetifier.blacklist=bcprov-jdk15on

--- a/services_app/build.gradle
+++ b/services_app/build.gradle
@@ -161,7 +161,7 @@ dependencies {
     testImplementation 'androidx.annotation:annotation:1.4.0'
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.robolectric:robolectric:4.8.1'
-
+    testImplementation 'android.arch.core:core-testing:1.1.1'
 }
 
 task grantPermissionForODKApp {

--- a/services_app/build.gradle
+++ b/services_app/build.gradle
@@ -154,11 +154,13 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'org.mockito:mockito-core:1.10.19'
+    androidTestImplementation 'org.mockito:mockito-core:2.19.0'
     androidTestImplementation 'com.google.truth:truth:1.1.3'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'androidx.annotation:annotation:1.3.0'
+    testImplementation 'androidx.annotation:annotation:1.4.0'
+    testImplementation 'androidx.test:core:1.4.0'
+    testImplementation 'org.robolectric:robolectric:4.8.1'
 
 }
 

--- a/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/AbsSyncViewModelTest.java
+++ b/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/AbsSyncViewModelTest.java
@@ -15,13 +15,17 @@ import org.opendatakit.sync.service.SyncAttachmentState;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.time.LocalTime;
+import java.sql.Timestamp;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = {Build.VERSION_CODES.O_MR1})
 public class AbsSyncViewModelTest {
 
     private AbsSyncViewModel absSyncViewModel;
+    private final String APP_NAME = "testAppName";
+    private final String USER_NAME = "testUser";
+    private final String TEST_SERVER_URL = "https://testUrl.com";
+    private final String LAST_SYNC_TIME = "2022-03-19 12:30:02";
 
     @Before
     public void setUp() throws Exception {
@@ -29,10 +33,9 @@ public class AbsSyncViewModelTest {
     }
 
     @Test
-    public void checkIfAppName_isAvailable() throws Exception {
-        String appName = "appName";
-        absSyncViewModel.setAppName(appName);
-        assertEquals(appName, absSyncViewModel.getAppName());
+    public void checkIfAppName_isAvailable() {
+        absSyncViewModel.setAppName(APP_NAME);
+        assertEquals(APP_NAME, absSyncViewModel.getAppName());
     }
 
     @Test
@@ -42,16 +45,15 @@ public class AbsSyncViewModelTest {
     }
 
     @Test
-    public void checkIfIsFirstLaunched_isAllowed() throws Exception {
+    public void checkIfIsFirstLaunched_isAllowed() {
         absSyncViewModel.setIsFirstLaunch(true);
         assertEquals(true, absSyncViewModel.checkIsFirstLaunch().getValue());
     }
 
     @Test
-    public void checkIfServerUrl_isAvailable() throws Exception {
-        String serverUrl = "https://odk-x.org/";
-        absSyncViewModel.setServerUrl(serverUrl);
-        assertEquals(serverUrl, absSyncViewModel.getServerUrl().getValue());
+    public void checkIfServerUrl_isAvailable() {
+        absSyncViewModel.setServerUrl(TEST_SERVER_URL);
+        assertEquals(TEST_SERVER_URL, absSyncViewModel.getServerUrl().getValue());
     }
 
     @Test
@@ -83,9 +85,8 @@ public class AbsSyncViewModelTest {
 
     @Test
     public void checkIfUserName_isAvailable() {
-        String userName = "john";
-        absSyncViewModel.setUsername(userName);
-        assertEquals(userName, absSyncViewModel.getUsername().getValue());
+        absSyncViewModel.setUsername(USER_NAME);
+        assertEquals(USER_NAME, absSyncViewModel.getUsername().getValue());
     }
 
     @Test
@@ -96,9 +97,9 @@ public class AbsSyncViewModelTest {
 
     @Test
     public void checkIfLastSyncTime_isVisible() {
-        long time = LocalTime.parse("12:30").getHour();
-        absSyncViewModel.setLastSyncTime(time);
-        assertEquals(String.valueOf(time), absSyncViewModel.getLastSyncTime().getValue().toString());
+        Timestamp time = Timestamp.valueOf(LAST_SYNC_TIME);
+        absSyncViewModel.setLastSyncTime(time.getTime());
+        assertEquals(String.valueOf(time.getTime()), absSyncViewModel.getLastSyncTime().getValue().toString());
     }
 
     @Test
@@ -111,7 +112,6 @@ public class AbsSyncViewModelTest {
     public void checkIfSyncAttachmentState_isAvailable() {
         absSyncViewModel.updateSyncAttachmentState(SyncAttachmentState.REDUCED_SYNC);
         assertEquals(SyncAttachmentState.REDUCED_SYNC, absSyncViewModel.getCurrentSyncAttachmentState());
-        absSyncViewModel.getSyncAttachmentState();
         assertNotNull(absSyncViewModel.getSyncAttachmentState().getValue());
     }
 }

--- a/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/AbsSyncViewModelTest.java
+++ b/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/AbsSyncViewModelTest.java
@@ -1,0 +1,117 @@
+package org.opendatakit.services.sync.actions.viewModels.viewModels;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.os.Build;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opendatakit.services.sync.actions.viewModels.AbsSyncViewModel;
+import org.opendatakit.services.utilities.UserState;
+import org.opendatakit.sync.service.SyncAttachmentState;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.time.LocalTime;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.O_MR1})
+public class AbsSyncViewModelTest {
+
+    private AbsSyncViewModel absSyncViewModel;
+
+    @Before
+    public void setUp() throws Exception {
+        absSyncViewModel = new AbsSyncViewModel();
+    }
+
+    @Test
+    public void checkAppName() throws Exception {
+        String appName = "appName";
+        absSyncViewModel.setAppName(appName);
+        assertEquals(appName, absSyncViewModel.getAppName());
+    }
+
+    @Test
+    public void checkIfStarted() {
+        absSyncViewModel.setStarted(true);
+        assertTrue(absSyncViewModel.getStarted());
+    }
+
+    @Test
+    public void checkIfIsFirstLaunched() throws Exception {
+        absSyncViewModel.setIsFirstLaunch(true);
+        assertEquals(true, absSyncViewModel.checkIsFirstLaunch().getValue());
+    }
+
+    @Test
+    public void checkServerUrl() throws Exception {
+        String serverUrl = "https://odk-x.org/";
+        absSyncViewModel.setServerUrl(serverUrl);
+        assertEquals(serverUrl, absSyncViewModel.getServerUrl().getValue());
+    }
+
+    @Test
+    public void checkIfIsServerVerified() {
+        absSyncViewModel.setIsServerVerified(true);
+        assertEquals(true, absSyncViewModel.checkIsServerVerified().getValue());
+    }
+
+    @Test
+    public void checkIfIsAnonymousSignInUsed() {
+        absSyncViewModel.setIsAnonymousSignInUsed(true);
+        assertEquals(true, absSyncViewModel.checkIsAnonymousSignInUsed().getValue());
+    }
+
+    @Test
+    public void checkIsAnonymousAllowed() {
+        absSyncViewModel.setIsAnonymousAllowed(true);
+        assertEquals(true, absSyncViewModel.checkIsAnonymousAllowed().getValue());
+        assertTrue(absSyncViewModel.isAnonymousAllowed());
+
+    }
+
+    @Test
+    public void checkCurrentUserState() {
+        absSyncViewModel.setCurrentUserState(UserState.LOGGED_OUT);
+        assertEquals(UserState.LOGGED_OUT, absSyncViewModel.getCurrentUserState().getValue());
+        assertNotNull(absSyncViewModel.getUserState());
+    }
+
+    @Test
+    public void checkUserName() {
+        String userName = "john";
+        absSyncViewModel.setUsername(userName);
+        assertEquals(userName, absSyncViewModel.getUsername().getValue());
+    }
+
+    @Test
+    public void checkIsUserVerified() {
+        absSyncViewModel.setIsUserVerified(true);
+        assertEquals(true, absSyncViewModel.checkIsUserVerified().getValue());
+    }
+
+    @Test
+    public void checkLastSyncTime() {
+        long time = LocalTime.parse("12:30").getHour();
+        absSyncViewModel.setLastSyncTime(time);
+        assertEquals(String.valueOf(time), absSyncViewModel.getLastSyncTime().getValue().toString());
+    }
+
+    @Test
+    public void checkIsLastSyncTimeAvailable() {
+        absSyncViewModel.setIsLastSyncTimeAvailable(true);
+        assertEquals(true, absSyncViewModel.checkIsLastSyncTimeAvailable().getValue());
+    }
+
+    @Test
+    public void checkSyncAttachmentState() {
+        absSyncViewModel.updateSyncAttachmentState(SyncAttachmentState.REDUCED_SYNC);
+        assertEquals(SyncAttachmentState.REDUCED_SYNC, absSyncViewModel.getCurrentSyncAttachmentState());
+        absSyncViewModel.getSyncAttachmentState();
+        assertNotNull(absSyncViewModel.getSyncAttachmentState().getValue());
+    }
+}

--- a/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/AbsSyncViewModelTest.java
+++ b/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/AbsSyncViewModelTest.java
@@ -29,45 +29,45 @@ public class AbsSyncViewModelTest {
     }
 
     @Test
-    public void checkAppName() throws Exception {
+    public void checkIfAppName_isAvailable() throws Exception {
         String appName = "appName";
         absSyncViewModel.setAppName(appName);
         assertEquals(appName, absSyncViewModel.getAppName());
     }
 
     @Test
-    public void checkIfStarted() {
+    public void checkIfAbsSyncViewModel_isStarted() {
         absSyncViewModel.setStarted(true);
         assertTrue(absSyncViewModel.getStarted());
     }
 
     @Test
-    public void checkIfIsFirstLaunched() throws Exception {
+    public void checkIfIsFirstLaunched_isAllowed() throws Exception {
         absSyncViewModel.setIsFirstLaunch(true);
         assertEquals(true, absSyncViewModel.checkIsFirstLaunch().getValue());
     }
 
     @Test
-    public void checkServerUrl() throws Exception {
+    public void checkIfServerUrl_isAvailable() throws Exception {
         String serverUrl = "https://odk-x.org/";
         absSyncViewModel.setServerUrl(serverUrl);
         assertEquals(serverUrl, absSyncViewModel.getServerUrl().getValue());
     }
 
     @Test
-    public void checkIfIsServerVerified() {
+    public void checkIfServer_isVerified() {
         absSyncViewModel.setIsServerVerified(true);
         assertEquals(true, absSyncViewModel.checkIsServerVerified().getValue());
     }
 
     @Test
-    public void checkIfIsAnonymousSignInUsed() {
+    public void checkIfAnonymousSignInUsed_isAllowed() {
         absSyncViewModel.setIsAnonymousSignInUsed(true);
         assertEquals(true, absSyncViewModel.checkIsAnonymousSignInUsed().getValue());
     }
 
     @Test
-    public void checkIsAnonymousAllowed() {
+    public void checkIfAnonymous_isAllowed() {
         absSyncViewModel.setIsAnonymousAllowed(true);
         assertEquals(true, absSyncViewModel.checkIsAnonymousAllowed().getValue());
         assertTrue(absSyncViewModel.isAnonymousAllowed());
@@ -75,40 +75,40 @@ public class AbsSyncViewModelTest {
     }
 
     @Test
-    public void checkCurrentUserState() {
+    public void checkIfCurrentUserState_isAvailable() {
         absSyncViewModel.setCurrentUserState(UserState.LOGGED_OUT);
         assertEquals(UserState.LOGGED_OUT, absSyncViewModel.getCurrentUserState().getValue());
         assertNotNull(absSyncViewModel.getUserState());
     }
 
     @Test
-    public void checkUserName() {
+    public void checkIfUserName_isAvailable() {
         String userName = "john";
         absSyncViewModel.setUsername(userName);
         assertEquals(userName, absSyncViewModel.getUsername().getValue());
     }
 
     @Test
-    public void checkIsUserVerified() {
+    public void checkIfUser_isVerified() {
         absSyncViewModel.setIsUserVerified(true);
         assertEquals(true, absSyncViewModel.checkIsUserVerified().getValue());
     }
 
     @Test
-    public void checkLastSyncTime() {
+    public void checkIfLastSyncTime_isVisible() {
         long time = LocalTime.parse("12:30").getHour();
         absSyncViewModel.setLastSyncTime(time);
         assertEquals(String.valueOf(time), absSyncViewModel.getLastSyncTime().getValue().toString());
     }
 
     @Test
-    public void checkIsLastSyncTimeAvailable() {
+    public void checkIFLastSyncTimeAvailable_isAllowed() {
         absSyncViewModel.setIsLastSyncTimeAvailable(true);
         assertEquals(true, absSyncViewModel.checkIsLastSyncTimeAvailable().getValue());
     }
 
     @Test
-    public void checkSyncAttachmentState() {
+    public void checkIfSyncAttachmentState_isAvailable() {
         absSyncViewModel.updateSyncAttachmentState(SyncAttachmentState.REDUCED_SYNC);
         assertEquals(SyncAttachmentState.REDUCED_SYNC, absSyncViewModel.getCurrentSyncAttachmentState());
         absSyncViewModel.getSyncAttachmentState();

--- a/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/LoginViewModelTest.java
+++ b/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/LoginViewModelTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opendatakit.services.sync.actions.LoginActions;
 import org.opendatakit.services.sync.actions.viewModels.LoginViewModel;
+import org.opendatakit.services.utilities.Constants;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -31,7 +32,7 @@ public class LoginViewModelTest {
 
     @Test
     public void checkIfFunctionTypes_isAvailable() {
-        loginViewModel.updateFunctionType("function");
-        assertEquals("function", loginViewModel.getFunctionType().getValue());
+        loginViewModel.updateFunctionType(Constants.LOGIN_TYPE_SIGN_IN);
+        assertEquals(Constants.LOGIN_TYPE_SIGN_IN, loginViewModel.getFunctionType().getValue());
     }
 }

--- a/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/LoginViewModelTest.java
+++ b/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/LoginViewModelTest.java
@@ -1,0 +1,37 @@
+package org.opendatakit.services.sync.actions.viewModels.viewModels;
+
+import static org.junit.Assert.assertEquals;
+
+import android.os.Build;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opendatakit.services.sync.actions.LoginActions;
+import org.opendatakit.services.sync.actions.viewModels.LoginViewModel;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.O_MR1})
+public class LoginViewModelTest {
+
+    private LoginViewModel loginViewModel;
+
+    @Before
+    public void setUp() throws Exception {
+        loginViewModel = new LoginViewModel();
+    }
+
+    @Test
+    public void checkIfLoginActions_isAvailable() {
+        loginViewModel.updateLoginAction(LoginActions.MONITOR_VERIFYING);
+        assertEquals(LoginActions.MONITOR_VERIFYING, loginViewModel.getCurrentAction());
+    }
+
+    @Test
+    public void checkIfFunctionTypes_isAvailable() {
+        loginViewModel.updateFunctionType("function");
+        assertEquals("function", loginViewModel.getFunctionType().getValue());
+    }
+}

--- a/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/PreferenceViewModelTest.java
+++ b/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/PreferenceViewModelTest.java
@@ -1,0 +1,41 @@
+package org.opendatakit.services.sync.actions.viewModels.viewModels;
+
+import static org.junit.Assert.assertEquals;
+
+import android.os.Build;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opendatakit.services.preferences.PreferenceViewModel;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.O_MR1})
+public class PreferenceViewModelTest {
+
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+    private PreferenceViewModel preferenceViewModel;
+
+    @Before
+    public void setUp() throws Exception {
+        preferenceViewModel = new PreferenceViewModel();
+    }
+
+    @Test
+    public void checkIfAdmin_isConfigured() throws InterruptedException {
+        preferenceViewModel.setAdminConfigured(true);
+        assertEquals(true, preferenceViewModel.getAdminConfigured().getValue());
+    }
+
+    @Test
+    public void checkIfAdminMode_isAllowed() {
+        preferenceViewModel.setAdminMode(true);
+        assertEquals(true, preferenceViewModel.getAdminMode().getValue());
+    }
+}

--- a/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/SyncViewModelTest.java
+++ b/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/SyncViewModelTest.java
@@ -1,0 +1,31 @@
+package org.opendatakit.services.sync.actions.viewModels.viewModels;
+
+import static org.junit.Assert.assertEquals;
+
+import android.os.Build;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opendatakit.services.sync.actions.SyncActions;
+import org.opendatakit.services.sync.actions.viewModels.SyncViewModel;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.O_MR1})
+public class SyncViewModelTest {
+
+    private SyncViewModel syncViewModel;
+
+    @Before
+    public void setUp() throws Exception {
+        syncViewModel = new SyncViewModel();
+    }
+
+    @Test
+    public void checkIfSyncAction_isAvailable() {
+        syncViewModel.updateSyncAction(SyncActions.SYNC);
+        assertEquals(SyncActions.SYNC, syncViewModel.getCurrentAction());
+    }
+}

--- a/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/VerifyViewModelTest.java
+++ b/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/VerifyViewModelTest.java
@@ -1,0 +1,38 @@
+package org.opendatakit.services.sync.actions.viewModels.viewModels;
+
+import static org.junit.Assert.assertEquals;
+
+import android.os.Build;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opendatakit.services.sync.actions.VerifyServerSettingsActions;
+import org.opendatakit.services.sync.actions.viewModels.VerifyViewModel;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.O_MR1})
+public class VerifyViewModelTest {
+
+    private VerifyViewModel verifyViewModel;
+
+    @Before
+    public void setUp() throws Exception {
+        verifyViewModel = new VerifyViewModel();
+    }
+
+    @Test
+    public void checkIfVerifyActions_isAvailable() {
+        verifyViewModel.updateVerifyAction(VerifyServerSettingsActions.VERIFY);
+        assertEquals(VerifyServerSettingsActions.VERIFY, verifyViewModel.getCurrentAction());
+    }
+
+    @Test
+    public void checkVerifyType_isVisible() {
+        String verifyType = "verified";
+        verifyViewModel.setVerifyType(verifyType);
+        assertEquals(verifyType, verifyViewModel.getVerifyType());
+    }
+}

--- a/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/VerifyViewModelTest.java
+++ b/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/VerifyViewModelTest.java
@@ -17,6 +17,7 @@ import org.robolectric.annotation.Config;
 public class VerifyViewModelTest {
 
     private VerifyViewModel verifyViewModel;
+    private final String TEST_VERIFY_TYPE = "server";
 
     @Before
     public void setUp() throws Exception {
@@ -31,8 +32,7 @@ public class VerifyViewModelTest {
 
     @Test
     public void checkVerifyType_isVisible() {
-        String verifyType = "verified";
-        verifyViewModel.setVerifyType(verifyType);
-        assertEquals(verifyType, verifyViewModel.getVerifyType());
+        verifyViewModel.setVerifyType(TEST_VERIFY_TYPE);
+        assertEquals(TEST_VERIFY_TYPE, verifyViewModel.getVerifyType());
     }
 }


### PR DESCRIPTION
Tested various MutableLiveData ViewModel classes for the following packages:
- ### package org.opendatakit.services.sync.actions.viewModels;
   - AbsSyncViewModel
   - LoginViewModel
   - SyncViewModel
   - VerifyViewModel
- ### package org.opendatakit.services.preferences;
   - PreferenceViewModel
   - Added **android.arch.core.executor.testing.InstantTaskExecutorRule**:  swaps the background executor used by the Architecture Components with a different one which executes each task synchronously.
   
![Screenshot from 2022-06-27 15-37-32](https://user-images.githubusercontent.com/57134307/175919110-91c41bc0-6a02-465f-88dd-9976f39fe125.png)

