### PR TITLE
Update GroupsPermissionTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project is __*actively maintained*__
 
-It is part of the ODK-X Android tools suite.  
+It is part of the ODK-X Android tools suite.
 
 Prior to rev 200, this repo was the __*core*__ repo.
 
@@ -18,7 +18,7 @@ General instructions for setting up an ODK-X environment can be found at our [De
 
 Install [Android Studio](http://developer.android.com/tools/studio/index.html) and the [SDK](http://developer.android.com/sdk/index.html#Other).
 
-This project depends on ODK-X's [androidlibrary](https://github.com/odk-x/androidlibrary) and [androidcommon](https://github.com/odk-x/androidcommon) projects; their binaries will be downloaded automatically from our maven repository during the build phase. If you wish to modify them yourself, you must clone them into the same parent directory as survey. You directory stucture should resemble the following:
+This project depends on ODK-X's [androidlibrary](https://github.com/odk-x/androidlibrary) and [androidcommon](https://github.com/odk-x/androidcommon) projects; their binaries will be downloaded automatically from our maven repository during the build phase. If you wish to modify them yourself, you must clone them into the same parent directory as survey. You directory structure should resemble the following:
 
         |-- odk-x
 
@@ -68,7 +68,7 @@ Once you’re up and running, you can choose an issue to start working on from h
 
 Issues tagged as [good first issue](https://github.com/odk-x/tool-suite-X/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) should be a good place to start.
 
-Pull requests are welcome, though please submit them against the development branch. We prefer verbose descriptions of the change you are submitting. If you are fixing a bug please provide steps to reproduce it or a link to a an issue that provides that information. If you are submitting a new feature please provide a description of the need or a link to a forum discussion about it. 
+Pull requests are welcome, though please submit them against the development branch. We prefer verbose descriptions of the change you are submitting. If you are fixing a bug please provide steps to reproduce it or a link to a an issue that provides that information. If you are submitting a new feature please provide a description of the need or a link to a forum discussion about it.
 
 ## Links for users
 This document is aimed at helping developers and technical contributors. For information on how to get started as a user of ODK-X, see our [online documentation](https://docs.odk-x.org), or to learn more about the Open Data Kit project, visit [https://odk-x.org](https://odk-x.org).

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-gradle.ext.gradleConfigVersion = 155
+gradle.ext.gradleConfigVersion = 156
 
 if (!gradle.ext.has('workspacePath')) {
     logger.warn("rootDir: " + rootDir.getAbsolutePath());


### PR DESCRIPTION
This is a PR for[ Isses 447](https://github.com/odk-x/tool-suite-X/issues/447)

# PR Description

- Update `InstrumentationRegistry.getTargetContext()` to `InstrumentationRegistry.getInstrumentation().getTargetContext()`
- Removed unused constant fields
- Removed unnecessary type arguments
-  Removed unnecessary boxing of Long.valueOf() e.g from `Long.valueOf(2)` to `2L`
- Finally run the test to be sure all the test still runs successfully

<img width="607" alt="Screenshot 2023-10-26 at 10 14 03 AM" src="https://github.com/odk-x/services/assets/107570182/e45373d6-0e40-483d-843a-83d5d80ebe30">

