### PR TITLE
Improvement: Test Coverage Improvement for AbsSync ViewModel

### DIFF
--- a/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/AbsSyncViewModelTest.java
+++ b/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/AbsSyncViewModelTest.java
@@ -200,7 +200,6 @@ public class AbsSyncViewModelTest extends BaseTest {
                 }
             }).start();
         }
-
         latch.await();
         assertTrue("Some threads encountered errors while accessing last sync time", allThreadsSuccessful.get());
     }

--- a/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/AbsSyncViewModelTest.java
+++ b/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/AbsSyncViewModelTest.java
@@ -122,31 +122,22 @@ public class AbsSyncViewModelTest extends BaseTest {
     }
 
     @Test
-    public void testNullAppName() {
+    public void testNullValues() {
         absSyncViewModel.setAppName(null);
         assertNull(absSyncViewModel.getAppName());
-    }
 
-    @Test
-    public void testNullServerUrl() {
         absSyncViewModel.setServerUrl(null);
         assertNull(absSyncViewModel.getServerUrl().getValue());
-    }
 
-    @Test
-    public void testNullUsername() {
         absSyncViewModel.setUsername(null);
         assertNull(absSyncViewModel.getUsername().getValue());
     }
 
     @Test
-    public void testIsFirstLaunchFlagTrue() {
+    public void testIsFirstLaunchFlags() {
         absSyncViewModel.setIsFirstLaunch(true);
         assertTrue(absSyncViewModel.checkIsFirstLaunch().getValue());
-    }
 
-    @Test
-    public void testIsFirstLaunchFlagFalse() {
         absSyncViewModel.setIsFirstLaunch(false);
         assertFalse(absSyncViewModel.checkIsFirstLaunch().getValue());
     }
@@ -164,23 +155,6 @@ public class AbsSyncViewModelTest extends BaseTest {
             absSyncViewModel.setCurrentUserState(state);
         }
         assertEquals(UserState.values()[UserState.values().length - 1], absSyncViewModel.getCurrentUserState().getValue());
-    }
-
-    @Test
-    public void testLastSyncTimeObserver() throws InterruptedException {
-        final CountDownLatch latch = new CountDownLatch(1);
-        final Observer<Long> observer = new Observer<Long>() {
-            @Override
-            public void onChanged(Long value) {
-                assertEquals(1000L, (long) value);
-                latch.countDown();
-            }
-        };
-
-        absSyncViewModel.getLastSyncTime().observeForever(observer);
-        absSyncViewModel.setLastSyncTime(1000L);
-        latch.await(2, TimeUnit.SECONDS);
-        absSyncViewModel.getLastSyncTime().removeObserver(observer);
     }
 
     @Test

--- a/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/AbsSyncViewModelTest.java
+++ b/services_app/src/test/java/org/opendatakit/services/sync/actions/viewModels/viewModels/AbsSyncViewModelTest.java
@@ -1,10 +1,14 @@
 package org.opendatakit.services.sync.actions.viewModels.viewModels;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import android.os.Build;
+
+import androidx.lifecycle.Observer;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -17,6 +21,11 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.sql.Timestamp;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = {Build.VERSION_CODES.O_MR1})
@@ -111,4 +120,118 @@ public class AbsSyncViewModelTest extends BaseTest {
         assertEquals(SyncAttachmentState.REDUCED_SYNC, absSyncViewModel.getCurrentSyncAttachmentState());
         assertNotNull(absSyncViewModel.getSyncAttachmentState().getValue());
     }
+
+    @Test
+    public void testNullAppName() {
+        absSyncViewModel.setAppName(null);
+        assertNull(absSyncViewModel.getAppName());
+    }
+
+    @Test
+    public void testNullServerUrl() {
+        absSyncViewModel.setServerUrl(null);
+        assertNull(absSyncViewModel.getServerUrl().getValue());
+    }
+
+    @Test
+    public void testNullUsername() {
+        absSyncViewModel.setUsername(null);
+        assertNull(absSyncViewModel.getUsername().getValue());
+    }
+
+    @Test
+    public void testIsFirstLaunchFlagTrue() {
+        absSyncViewModel.setIsFirstLaunch(true);
+        assertTrue(absSyncViewModel.checkIsFirstLaunch().getValue());
+    }
+
+    @Test
+    public void testIsFirstLaunchFlagFalse() {
+        absSyncViewModel.setIsFirstLaunch(false);
+        assertFalse(absSyncViewModel.checkIsFirstLaunch().getValue());
+    }
+
+    @Test
+    public void testServerUrlExtremeValue() {
+        String longUrl = "http://" + String.join("", Collections.nCopies(100000, "a")) + ".com";
+        absSyncViewModel.setServerUrl(longUrl);
+        assertEquals(longUrl, absSyncViewModel.getServerUrl().getValue());
+    }
+
+    @Test
+    public void testUserState() {
+        for (UserState state : UserState.values()) {
+            absSyncViewModel.setCurrentUserState(state);
+        }
+        assertEquals(UserState.values()[UserState.values().length - 1], absSyncViewModel.getCurrentUserState().getValue());
+    }
+
+    @Test
+    public void testLastSyncTimeObserver() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Observer<Long> observer = new Observer<Long>() {
+            @Override
+            public void onChanged(Long value) {
+                assertEquals(1000L, (long) value);
+                latch.countDown();
+            }
+        };
+
+        absSyncViewModel.getLastSyncTime().observeForever(observer);
+        absSyncViewModel.setLastSyncTime(1000L);
+        latch.await(2, TimeUnit.SECONDS);
+        absSyncViewModel.getLastSyncTime().removeObserver(observer);
+    }
+
+    @Test
+    public void testConcurrentAccessToLastSyncTime() throws InterruptedException {
+        final int numThreads = 10;
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final AtomicBoolean allThreadsSuccessful = new AtomicBoolean(true);
+
+        for (int i = 0; i < numThreads; i++) {
+            new Thread(() -> {
+                try {
+                    Long currentLastSyncTime = absSyncViewModel.getLastSyncTime().getValue();
+                } catch (Exception e) {
+                    allThreadsSuccessful.set(false);
+                } finally {
+                    latch.countDown();
+                }
+            }).start();
+        }
+
+        latch.await();
+        assertTrue("Some threads encountered errors while accessing last sync time", allThreadsSuccessful.get());
+    }
+
+
+    @Test
+    public void testLastSyncTimeValueConsistencyAcrossThreads() throws InterruptedException {
+        final int numThreads = 10;
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final AtomicLong initialLastSyncTime = new AtomicLong();
+
+        Long initialValue = absSyncViewModel.getLastSyncTime().getValue();
+        initialLastSyncTime.set(initialValue != null ? initialValue : 0);
+
+        for (int i = 0; i < numThreads; i++) {
+            new Thread(() -> {
+                try {
+                    Long currentLastSyncTime = absSyncViewModel.getLastSyncTime().getValue();
+                    if (currentLastSyncTime != null && currentLastSyncTime != initialLastSyncTime.get()) {
+                        initialLastSyncTime.set(-1);
+                    }
+                } catch (Exception e) {
+                    initialLastSyncTime.set(-1);
+                } finally {
+                    latch.countDown();
+                }
+            }).start();
+        }
+
+        latch.await();
+        assertEquals("Last sync time is consistent across threads", 0, initialLastSyncTime.get());
+    }
+
 }


### PR DESCRIPTION
This is a pull request raised for issue https://github.com/odk-x/tool-suite-X/issues/447

Reason for improvement
These tests ensure the robustness and reliability of the AbsSyncViewModel class by covering essential scenarios. They verify the ViewModel's ability to handle null values gracefully for properties like appName, serverUrl, and username. Additionally, the tests confirm the correct behavior of the isFirstLaunch flag under both true and false conditions. The extreme case of a long server URL is also checked to ensure the ViewModel can handle such inputs without issues. Furthermore, concurrency tests assess the ViewModel's performance under multiple threads, ensuring consistent behavior when accessing the last sync time property. Overall, these tests collectively strengthen the quality of the AbsSyncViewModel class, enhancing its resilience in real-world usage scenarios.
![Screenshot 2024-03-05 175840](https://github.com/odk-x/services/assets/95471989/dc51ee66-6895-4212-a049-6be485183e39)
![Screenshot 2024-03-05 175930](https://github.com/odk-x/services/assets/95471989/cd91b35a-ed44-410e-9e0c-faca40b06ec6)
![Screenshot 2024-03-05 180004](https://github.com/odk-x/services/assets/95471989/bb2243a5-fd3b-4fc2-9ccd-3e394f33c6dd)
![Screenshot 2024-03-05 180035](https://github.com/odk-x/services/assets/95471989/211dd57b-229d-47b9-bd9b-578f0963654a)

Changes made to the AbsSyncViewModelTest.java class
1) It tests for when AppName, ServerURL, and Username is null.

2) it tests for when ifFirstLaunch is True or False

3) it tests for the different states of UserState

4) it test the live observer for lastSyncTime

5) it test for concurrent access to lastSyncTime

6) it tests for consistency in the value of lastSyncTime across threads.