### PR TITLE
`Fix` ODK-X Services: The App crashes due to a missing button style

### DIFF
--- a/services_app/src/main/res/drawable/button_border.xml
+++ b/services_app/src/main/res/drawable/button_border.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <!-- Border -->
+    <stroke
+        android:width="1dp"
+        android:color="@color/colorPrimaryBackground" />
+
+    <!-- Outer background color -->
+    <solid android:color="@android:color/transparent" />
+
+    <!-- Corner radius -->
+    <corners android:radius="100dp" />
+</shape>

--- a/services_app/src/main/res/layout/fragment_choose_sign_in_type.xml
+++ b/services_app/src/main/res/layout/fragment_choose_sign_in_type.xml
@@ -46,7 +46,7 @@
         android:id="@+id/btnAnonymousSignInLogin"
         style="@style/ButtonStyleAnonymous"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="40dp"
         android:layout_margin="@dimen/portrait_regular_margin"
         android:text="@string/anonymous_user"
         app:layout_constraintBottom_toTopOf="@+id/btnUserSignInLogin"
@@ -61,11 +61,10 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/portrait_regular_margin"
-
         android:text="@string/authenticated_user"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.333"
+        app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/btnAnonymousSignInLogin"
         tools:ignore="TextContrastCheck" />

--- a/services_app/src/main/res/values/styles.xml
+++ b/services_app/src/main/res/values/styles.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
-
+<resources>
 
     <!--NavViewTheme-->
     <style name="NavViewTheme" parent="ODKX">
@@ -10,12 +9,23 @@
         <item name="itemIconSize">20dp</item>
         <item name="itemTextAppearance">@style/TextViewStyle</item>
         <item name="cornerRadius">@dimen/rounder_corners</item>
-       <!-- <item name="itemShapeFillColor">@color/navigation_item_background_color</item> -->
+        <!-- <item name="itemShapeFillColor">@color/navigation_item_background_color</item> -->
         <!-- <item name="itemTextColor">@color/navigation_item_color</item> -->
         <item name="android:dividerHeight">0dp</item>
         <item name="android:dividerPadding">4dp</item>
-       <item name="headerLayout">@layout/drawer_header</item>
+        <item name="headerLayout">@layout/drawer_header</item>
         <item name="menu">@menu/drawer_menu</item>
+    </style>
+
+    <style name="ButtonStyleAnonymous">
+        <item name="android:textAllCaps">true</item>
+        <item name="android:textSize">14sp</item>
+        <item name="elevation">0dp</item>
+        <item name="backgroundTint">@color/btn_background</item>
+        <item name="fontFamily">@font/sourcesanspro_regular</item>
+        <item name="android:textColor">@color/colorPrimaryBackground</item>
+        <item name="cornerRadius">100dp</item>
+        <item name="android:background">@drawable/button_border</item>
     </style>
 
 </resources>


### PR DESCRIPTION
This fixes [ODK-X Services: The App crashes due to a missing button style](https://github.com/odk-x/tool-suite-X/issues/469) issue.

## From:
<img width="1504" alt="Style Error" src="https://github.com/odk-x/services/assets/54077752/571b1665-b223-499f-afbc-e15d01c7d8a0">

## To:
![Screenshot from 2024-03-06 03-53-54](https://github.com/odk-x/services/assets/54077752/5bf5754d-2f0c-4af5-96ad-350dab1c4bdf)

The app now works just fine on `upgrade-jdk11` branch!