### PR TITLE
Fix Broken GeneralAppPropertiesActivity UI test

### DIFF
--- a/services_app/src/androidTest/java/org/opendatakit/services/preferences/activities/GeneralAppPropertiesActivityTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/preferences/activities/GeneralAppPropertiesActivityTest.java
@@ -40,16 +40,16 @@ public class GeneralAppPropertiesActivityTest extends BaseUITest<AppPropertiesAc
 
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
+
     @Test
     public void whenOpenDocumentationScreenIsClicked_launchUrl() {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(0, scrollTo()))
-                .check(matches(atPosition(0, hasDescendant(withText(R.string.opendatakit_website)))));
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(7, scrollTo()))
+                .check(matches(atPosition(7, hasDescendant(withText(R.string.user_documentation)))));
         onView(allOf(withId(android.R.id.summary),
-                childAtPosition(withId(androidx.preference.R.id.recycler_view), 0),
-                isDisplayed())).check(matches(withText(R.string.click_to_web)));
+                childAtPosition(withId(androidx.preference.R.id.recycler_view), 7),
+                isDisplayed())).check(matches(withText(R.string.visit_user_docs)));
         onView(withId(androidx.preference.R.id.recycler_view))
-                .perform(RecyclerViewActions.actionOnItemAtPosition(0,
+                .perform(RecyclerViewActions.actionOnItemAtPosition(7,
                         click()));
     }
 
@@ -64,48 +64,47 @@ public class GeneralAppPropertiesActivityTest extends BaseUITest<AppPropertiesAc
     }
 
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void checkIfDeviceSettingScreen_isVisible() {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(2, scrollTo()))
-                .check(matches(atPosition(2, hasDescendant(withText(R.string.device)))));
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(4, scrollTo()))
+                .check(matches(atPosition(4, hasDescendant(withText(R.string.preferences)))));
         onView(allOf(withId(android.R.id.summary),
-                childAtPosition(withId(androidx.preference.R.id.recycler_view), 2),
-                isDisplayed())).check(matches(withText(R.string.device_settings_summary)));
+                childAtPosition(withId(androidx.preference.R.id.recycler_view), 4),
+                isDisplayed())).check(matches(withText(R.string.configure_device_settings)));
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
+
     @Test
     public void checkIfTableSpecificSettingScreen_isVisible() {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(3, scrollTo()))
-                .check(matches(atPosition(3, hasDescendant(withText(R.string.tool_tables_settings)))));
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(5, scrollTo()))
+                .check(matches(atPosition(5, hasDescendant(withText(R.string.odkx_tables)))));
         onView(allOf(withId(android.R.id.summary),
-                childAtPosition(withId(androidx.preference.R.id.recycler_view), 3),
+                childAtPosition(withId(androidx.preference.R.id.recycler_view), 5),
                 isDisplayed())).check(matches(withText(R.string.tool_tables_settings_summary)));
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
+
     @Test
     public void checkIfEnableUserRestrictionScreen_isVisible() {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(4, scrollTo()))
-                .check(matches(atPosition(4, hasDescendant(withText(R.string.enable_admin_password)))));
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(3, scrollTo()))
+                .check(matches(atPosition(3, hasDescendant(withText(R.string.user_restrictions)))));
 
         onView(allOf(withId(android.R.id.summary),
-                childAtPosition(withId(androidx.preference.R.id.recycler_view), 4),
-                isDisplayed())).check(matches(withText(R.string.admin_password_disabled)));
+                childAtPosition(withId(androidx.preference.R.id.recycler_view), 3),
+                isDisplayed())).check(matches(withText(R.string.enable_user_restrictions)));
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
+
     @Test
     public void whenResetConfigurationScreenIsClicked_launchResetConfigurationDialog() {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(5, scrollTo()))
-                .check(matches(atPosition(5, hasDescendant(withText(R.string.clear_configuration_settings)))));
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(6, scrollTo()))
+                .check(matches(atPosition(6, hasDescendant(withText(R.string.clear_settings)))));
         onView(allOf(withId(android.R.id.summary),
-                childAtPosition(withId(androidx.preference.R.id.recycler_view), 5),
-                isDisplayed())).check(matches(withText(R.string.click_to_clear_settings)));
+                childAtPosition(withId(androidx.preference.R.id.recycler_view), 6),
+                isDisplayed())).check(matches(withText(R.string.reset_configuration)));
 
         onView(withId(androidx.preference.R.id.recycler_view))
-                .perform(RecyclerViewActions.actionOnItemAtPosition(5,
+                .perform(RecyclerViewActions.actionOnItemAtPosition(6,
                         click()));
         onView(withText(R.string.reset_settings))
                 .inRoot(isDialog())
@@ -114,13 +113,13 @@ public class GeneralAppPropertiesActivityTest extends BaseUITest<AppPropertiesAc
         onView(allOf(withId(android.R.id.button1), withText("OK"))).perform(click());
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
+
     @Test
     public void checkIfVerifyUserPermissionScreen_isVisible() {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(6, scrollTo()))
-                .check(matches(atPosition(6, hasDescendant(withText(R.string.verify_server_settings_start)))));
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(2, scrollTo()))
+                .check(matches(atPosition(2, hasDescendant(withText(R.string.verify_server_settings_header)))));
         onView(allOf(withId(android.R.id.summary),
-                childAtPosition(withId(androidx.preference.R.id.recycler_view), 6),
+                childAtPosition(withId(androidx.preference.R.id.recycler_view), 2),
                 isDisplayed())).check(matches(withText(R.string.click_to_verify_server_settings)));
     }
 


### PR DESCRIPTION
# This is a pull request raised for issue https://github.com/odk-x/tool-suite-X/issues/470

## Reason for Fix:
The UI test for the settings screen was broken following a rework of the settings screen. As a result, the strings to be matched weren't referenced correctly and the position of the item to be clicked were out of order. this raised the need for some refactoring to fix the broken UI test.
![Screenshot 2024-03-23 121305](https://github.com/odk-x/services/assets/95471989/afabd708-f0e0-4c58-a426-5b4bbcd6e1d9)
![Screenshot 2024-03-23 121412](https://github.com/odk-x/services/assets/95471989/2e740a01-5cb2-40bf-8247-5fcab7f523ba)
![Screenshot 2024-03-23 121444](https://github.com/odk-x/services/assets/95471989/60d39c33-b1e3-40a3-917d-fe6f9bc172da)

## Changes made to the GeneralAppPropertiesActivityTest class

### 1 Corrected the referenced to the matched strings in the following tests:
      -whenOpenDocumentationScreenIsClicked_launchUrl()
     -checkIfDeviceSettingScreen_isVisible()
     -checkIfTableSpecificSettingScreen_isVisible()
     -checkIfEnableUserRestrictionScreen_isVisible()
     -whenResetConfigurationScreenIsClicked_launchResetConfigurationDialog()
     -checkIfVerifyUserPermissionScreen_isVisible()

### 2 corrected the position of item on the list for
     -whenOpenDocumentationScreenIsClicked_launchUrl()
     -checkIfDeviceSettingScreen_isVisible()
     -checkIfTableSpecificSettingScreen_isVisible()
     -checkIfEnableUserRestrictionScreen_isVisible()
     -whenResetConfigurationScreenIsClicked_launchResetConfigurationDialog()
     -checkIfVerifyUserPermissionScreen_isVisible()

![Screenshot 2024-03-29 210905](https://github.com/odk-x/services/assets/95471989/9f9924b6-5265-45e5-977c-5734bd9ded8a)

