### PR TITLE
Fix Broken AdminAppPropertiesActivity UI test

### DIFF
--- a/services_app/src/androidTest/java/org/opendatakit/BaseUITest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/BaseUITest.java
@@ -190,14 +190,12 @@ public abstract class BaseUITest<T extends Activity> {
 
     public  static void enableAdminMode() {
         onView(withId(androidx.preference.R.id.recycler_view))
-                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.enable_admin_password)),
+                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.user_restrictions)),
                         click()));
         onView(withId(androidx.preference.R.id.recycler_view))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(1,
                         click()));
-        onView(withText(R.string.change_admin_password))
-                .inRoot(isDialog())
-                .check(matches(isDisplayed()));
+        onView(withId(R.id.pwd_field)).perform(click());
         onView(withId(R.id.pwd_field)).perform(replaceText(TEST_PASSWORD));
         onView(withId(R.id.positive_button)).perform(ViewActions.click());
     }

--- a/services_app/src/androidTest/java/org/opendatakit/services/preferences/activities/AdminAppPropertiesActivityTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/preferences/activities/AdminAppPropertiesActivityTest.java
@@ -5,9 +5,13 @@ import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.google.common.truth.Truth.assertThat;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.opendatakit.utilities.ViewMatchers.childAtPosition;
 
 import android.content.Intent;
 
@@ -29,58 +33,70 @@ public class AdminAppPropertiesActivityTest extends BaseUITest<AppPropertiesActi
             PropertiesSingleton props = activity.getProps();
             assertThat(props).isNotNull();
         });
+        onView(withId(R.id.app_properties_content)).check(matches(isDisplayed()));
         enableAdminMode();
         Espresso.pressBack();
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void checkIfChangeAdminPasswordScreen_isVisible() {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(4, scrollTo()))
-                .check(matches(atPosition(4, hasDescendant(withText(R.string.change_admin_password)))));
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(3, scrollTo()))
+                .check(matches(atPosition(3, hasDescendant(withText(R.string.change_admin_password)))));
+        onView(allOf(withId(android.R.id.summary),
+                childAtPosition(withId(androidx.preference.R.id.recycler_view), 3),
+                isDisplayed())).check(matches(withText(R.string.admin_password_enabled)));
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void checkIfManageAbilityToChangeServerSettingScreen_isVisible() {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(5, scrollTo()))
-                .check(matches(atPosition(5, hasDescendant(withText(R.string.restrict_server)))));
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(8, scrollTo()))
+                .check(matches(atPosition(8, hasDescendant(withText(R.string.restrict_server)))));
+        onView(allOf(withId(android.R.id.summary),
+                childAtPosition(withId(androidx.preference.R.id.recycler_view), 8),
+                isDisplayed())).check(matches(withText(R.string.restrict_server_settings_summary)));
     }
 
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void checkIfManageAbilityToChangeDeviceSettingScreen_isVisible() {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(6, scrollTo()))
-                .check(matches(atPosition(6, hasDescendant(withText(R.string.restrict_device)))));
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(9, scrollTo()))
+                .check(matches(atPosition(9, hasDescendant(withText(R.string.restrict_device)))));
+        onView(allOf(withId(android.R.id.summary),
+                childAtPosition(withId(androidx.preference.R.id.recycler_view), 9),
+                isDisplayed())).check(matches(withText(R.string.restrict_device_settings_summary)));
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void checkIfManageAbilityToChangeTableSpecificSettingScreen_isVisible() {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(7, scrollTo()))
-                .check(matches(atPosition(7, hasDescendant(withText(R.string.admin_tool_tables_settings)))));
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(10, scrollTo()))
+                .check(matches(atPosition(10, hasDescendant(withText(R.string.admin_tool_tables_settings)))));
+        onView(allOf(withId(android.R.id.summary),
+                childAtPosition(withId(androidx.preference.R.id.recycler_view), 10),
+                isDisplayed())).check(matches(withText(R.string.admin_tool_tables_settings_summary)));
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void checkIfResetConfigurationScreen_isVisible() {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(8, scrollTo()))
-                .check(matches(atPosition(8, hasDescendant(withText(R.string.clear_configuration_settings)))));
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(6, scrollTo()))
+                .check(matches(atPosition(6, hasDescendant(withText(R.string.clear_settings)))));
+        onView(allOf(withId(android.R.id.summary),
+                childAtPosition(withId(androidx.preference.R.id.recycler_view), 6),
+                isDisplayed())).check(matches(withText(R.string.clear_configuration_settings)));
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void checkIfExitAdminModeScreen_isVisible() {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(9, scrollTo()))
-                .check(matches(atPosition(9, hasDescendant(withText(R.string.exit_admin_mode)))));
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(11, scrollTo()))
+                .check(matches(atPosition(11, hasDescendant(withText(R.string.exit_admin_mode)))));
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void checkIfVerifyUserPermissionScreen_isVisible() {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(10, scrollTo()))
-                .check(matches(atPosition(10, hasDescendant(withText(R.string.verify_server_settings_start)))));
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(actionOnItemAtPosition(2, scrollTo()))
+                .check(matches(atPosition(2, hasDescendant(withText(R.string.verify_server_settings_header)))));
+        onView(allOf(withId(android.R.id.summary),
+                childAtPosition(withId(androidx.preference.R.id.recycler_view), 2),
+                isDisplayed())).check(matches(withText(R.string.click_to_verify_server_settings)));
     }
 
     @After


### PR DESCRIPTION
# This is a pull request raised for issue https://github.com/odk-x/tool-suite-X/issues/470

## Reason for Fix:
The UI test for the settings screen was broken following a rework of the settings screen for Admin Mode. As a result, the function that sets up the admin mode to enable the test run was broken, the strings to be matched weren't referenced correctly and the position of the item to be clicked were out of order. this raised the need for some refactoring to fix the broken UI test.

![Screenshot 2024-03-24 124243](https://github.com/odk-x/services/assets/95471989/4409f511-096b-443a-a696-50ab0f915f4d)

![Screenshot 2024-03-24 132405](https://github.com/odk-x/services/assets/95471989/8ae3cc1d-245a-4dd0-9fe6-aacd6d0939cb)

![Screenshot 2024-03-24 132441](https://github.com/odk-x/services/assets/95471989/8c86f3f8-f2af-4589-92da-d35d5617c15b)

## **Changes made to the BaseUITest class

  ---Fixed the enableAdminMode() function to correctly locate the enable admin setting button, click on it and enter the admin password

## **Changes made to the AdminAppPropertiesActivityTest class

### 1 Corrected the referenced to the matched strings in the following tests:
 -checkIfChangeAdminPasswordScreen_isVisible()
  -checkIfManageAbilityToChangeServerSettingScreen_isVisible()
  -checkIfManageAbilityToChangeDeviceSettingScreen_isVisible()
  -checkIfManageAbilityToChangeTableSpecificSettingScreen_isVisible()
  -checkIfResetConfigurationScreen_isVisible()
  -checkIfExitAdminModeScreen_isVisible()
  -checkIfVerifyUserPermissionScreen_isVisible()

### 2 Corrected the position of item on the list for
 -checkIfChangeAdminPasswordScreen_isVisible()
  -checkIfManageAbilityToChangeServerSettingScreen_isVisible()
  -checkIfManageAbilityToChangeDeviceSettingScreen_isVisible()
  -checkIfManageAbilityToChangeTableSpecificSettingScreen_isVisible()
  -checkIfResetConfigurationScreen_isVisible()
  -checkIfExitAdminModeScreen_isVisible()
  -checkIfVerifyUserPermissionScreen_isVisible()

### 3 Expanded the scope of test to match the summary description for
  -checkIfChangeAdminPasswordScreen_isVisible()
  -checkIfManageAbilityToChangeServerSettingScreen_isVisible()
  -checkIfManageAbilityToChangeDeviceSettingScreen_isVisible()
  -checkIfManageAbilityToChangeTableSpecificSettingScreen_isVisible()
  -checkIfResetConfigurationScreen_isVisible()
  -checkIfVerifyUserPermissionScreen_isVisible()

![Screenshot 2024-03-29 210502](https://github.com/odk-x/services/assets/95471989/c5d03ce9-61d2-4a57-a6de-524df521582a)
