### PR TITLE
Fix Broken UI Test for all General Configurable Settings 

### DIFF
--- a/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/GeneralAdminConfigurationTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/GeneralAdminConfigurationTest.java
@@ -47,18 +47,15 @@ public class GeneralAdminConfigurationTest extends BaseUITest<AppPropertiesActiv
 
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenEnableUserRestrictionIsClicked_enterAdminPassword() {
         onView(withId(androidx.preference.R.id.recycler_view))
-                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.enable_admin_password)),
+                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.user_restrictions)),
                         click()));
         onView(withId(androidx.preference.R.id.recycler_view))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(1,
                         click()));
-        onView(withText(R.string.change_admin_password))
-                .inRoot(isDialog())
-                .check(matches(isDisplayed()));
+        onView(withId(R.id.pwd_field)).perform(click());
         onView(withId(R.id.pwd_field)).perform(replaceText(TEST_PASSWORD));
         onView(withId(R.id.positive_button)).perform(ViewActions.click());
         onView(allOf(withId(android.R.id.summary),

--- a/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/GeneralDeviceSettingsFragmentTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/GeneralDeviceSettingsFragmentTest.java
@@ -36,11 +36,11 @@ public class GeneralDeviceSettingsFragmentTest extends BaseUITest<AppPropertiesA
 
         onView(withId(R.id.app_properties_content)).check(matches(isDisplayed()));
         onView(withId(androidx.preference.R.id.recycler_view))
-                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.device)),
+                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.preferences)),
                         click()));
 
     }
-    @Ignore // OUTREACHY-BROKEN-TEST
+
     @Test
     public void whenTextFontSizeIsClicked_doChangeFontSize_checkIfSizeIsExtraLarge() {
         onView(withId(androidx.preference.R.id.recycler_view))
@@ -53,7 +53,6 @@ public class GeneralDeviceSettingsFragmentTest extends BaseUITest<AppPropertiesA
                 childAtPosition(withId(androidx.preference.R.id.recycler_view), 2),
                 isDisplayed())).check(matches(withText(FONT_SIZE_XL)));
     }
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenTextFontSizeIsClicked_doChangeFontSize_checkIfSizeIsLarge() {
 
@@ -65,7 +64,6 @@ public class GeneralDeviceSettingsFragmentTest extends BaseUITest<AppPropertiesA
                 childAtPosition(withId(androidx.preference.R.id.recycler_view), 2),
                 isDisplayed())).check(matches(withText(FONT_SIZE_L)));
     }
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenTextFontSizeIsClicked_doChangeFontSize_checkIfSizeIsMedium() {
 
@@ -77,7 +75,6 @@ public class GeneralDeviceSettingsFragmentTest extends BaseUITest<AppPropertiesA
                 childAtPosition(withId(androidx.preference.R.id.recycler_view), 2),
                 isDisplayed())).check(matches(withText(FONT_SIZE_M)));
     }
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenTextFontSizeIsClicked_doChangeFontSize_checkIfSizeIsSmall() {
 
@@ -89,7 +86,6 @@ public class GeneralDeviceSettingsFragmentTest extends BaseUITest<AppPropertiesA
                 childAtPosition(withId(androidx.preference.R.id.recycler_view), 2),
                 isDisplayed())).check(matches(withText(FONT_SIZE_S)));
     }
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenTextFontSizeIsClicked_doChangeFontSize_checkIfSizeIsExtraSmall() {
 
@@ -101,7 +97,6 @@ public class GeneralDeviceSettingsFragmentTest extends BaseUITest<AppPropertiesA
                 childAtPosition(withId(androidx.preference.R.id.recycler_view), 2),
                 isDisplayed())).check(matches(withText(FONT_SIZE_XS)));
     }
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenShowSplashScreenIsClicked_selectSplashScreen() {
         onView(withId(androidx.preference.R.id.recycler_view))

--- a/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/GeneralServerSettingsFragmentTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/GeneralServerSettingsFragmentTest.java
@@ -120,16 +120,13 @@ public class GeneralServerSettingsFragmentTest extends BaseUITest<AppPropertiesA
     }
 
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenServerPasswordIsChanged_enterNewPassword() {
         onView(withId(androidx.preference.R.id.recycler_view))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(4,
                         click()));
-        onView(withText(R.string.change_server_password))
-                .inRoot(isDialog())
-                .check(matches(isDisplayed()));
-        onView(withId(R.id.pwd_field)).perform(replaceText(TEST_USERNAME));
+        onView(withId(R.id.pwd_field)).perform(click());
+        onView(withId(R.id.pwd_field)).perform(replaceText(TEST_PASSWORD));
         onView(withId(R.id.positive_button)).perform(ViewActions.click());
 
     }

--- a/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/GeneralTablesSettingsFragmentTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/GeneralTablesSettingsFragmentTest.java
@@ -38,12 +38,10 @@ public class GeneralTablesSettingsFragmentTest extends BaseUITest<AppPropertiesA
 
         onView(withId(R.id.app_properties_content)).check(matches(isDisplayed()));
         onView(withId(androidx.preference.R.id.recycler_view))
-                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.tool_tables_settings)),
+                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.odkx_tables)),
                         click()));
     }
 
-
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenTableSpecificSettingIsClicked_useCustomHomeScreen() {
         onView(withText(R.string.custom_home_screen)).check(matches(isDisplayed()));


### PR DESCRIPTION
# **This is a pull request raised for issue https://github.com/odk-x/tool-suite-X/issues/470

## **Reason for Fix:
There are configurable settings available for a normal user of the app and there are configurable settings available for a user with admin privileges. The UI tests for these settings screen was broken following a rework of the settings screen. This PR was raised to fix the broken UI Test for the configurable settings that are available to a general user. These tests includes the following:

   - GeneralAdminConfigurationTest.java
   - GeneralDeviceSettingsFragmentTest.java
   - GeneralServerSettingsFragmentTest.java
   - GeneralTablesSettingsFragmentTest.java
   
## **What was changed in these files:
 - GeneralAdminConfigurationTest.java
    --corrected the reference for the string to be matched.
    --fix the flow to enable the test enter the test password

 - GeneralDeviceSettingsFragmentTest.java
   --corrected the reference for the string to be matched.

  - GeneralServerSettingsFragmentTest.java
     --fix the flow to enable the test enter the test password
     --referenced the correct text to be entered as password

   - GeneralTablesSettingsFragmentTest.java
     --corrected the reference for the string to be matched.

## **N/B: The checkBarcodeScanner_IsVisible() test in GeneralServerSettingsFragmentTest.java is still marked as ignore cos I couldn't find a QR code option on that screen.

![Screenshot 2024-03-29 212834](https://github.com/odk-x/services/assets/95471989/b5fa8f3b-5d12-4da2-bdab-3ac959a13fe3)
![Screenshot 2024-03-29 212127](https://github.com/odk-x/services/assets/95471989/060f0a81-5e30-454d-85f4-52ecfee20dcb)
![Screenshot 2024-03-29 212257](https://github.com/odk-x/services/assets/95471989/7c9402a9-cf38-463a-af23-2a6af77c2eee)
![Screenshot 2024-03-29 212406](https://github.com/odk-x/services/assets/95471989/372ea64a-2761-4cba-97aa-e3dcda9b31fd)

  