### PR TITLE
Fix Broken UI Test for all Admin Configurable Settings 

### DIFF
--- a/services_app/src/androidTest/java/org/opendatakit/BaseUITest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/BaseUITest.java
@@ -195,6 +195,7 @@ public abstract class BaseUITest<T extends Activity> {
         onView(withId(androidx.preference.R.id.recycler_view))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(1,
                         click()));
+
         onView(withId(R.id.pwd_field)).perform(click());
         onView(withId(R.id.pwd_field)).perform(replaceText(TEST_PASSWORD));
         onView(withId(R.id.positive_button)).perform(ViewActions.click());

--- a/services_app/src/androidTest/java/org/opendatakit/BaseUITest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/BaseUITest.java
@@ -190,14 +190,12 @@ public abstract class BaseUITest<T extends Activity> {
 
     public  static void enableAdminMode() {
         onView(withId(androidx.preference.R.id.recycler_view))
-                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.enable_admin_password)),
+                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.user_restrictions)),
                         click()));
         onView(withId(androidx.preference.R.id.recycler_view))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(1,
                         click()));
-        onView(withText(R.string.change_admin_password))
-                .inRoot(isDialog())
-                .check(matches(isDisplayed()));
+        onView(withId(R.id.pwd_field)).perform(click());
         onView(withId(R.id.pwd_field)).perform(replaceText(TEST_PASSWORD));
         onView(withId(R.id.positive_button)).perform(ViewActions.click());
     }

--- a/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/AdminConfigurableDeviceSettingsFragmentTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/AdminConfigurableDeviceSettingsFragmentTest.java
@@ -45,7 +45,7 @@ public class AdminConfigurableDeviceSettingsFragmentTest extends BaseUITest<AppP
                         click()));
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
+
     @Test
     public void whenDeviceSpecificSettingsIsChangedInAdminMode_checkIfDeviceSettings_isDisabledInNonAdminMode() {
         setCheckboxValue(false);
@@ -66,7 +66,7 @@ public class AdminConfigurableDeviceSettingsFragmentTest extends BaseUITest<AppP
 
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
+
     @Test
     public void whenDeviceSpecificSettingsIsChangedInAdminMode_checkIfDeviceSettings_isEnabledInNonAdminMode() {
         setCheckboxValue(true);
@@ -106,7 +106,7 @@ public class AdminConfigurableDeviceSettingsFragmentTest extends BaseUITest<AppP
         onView(isRoot()).perform(waitFor(1000));
 
         onView(withId(androidx.preference.R.id.recycler_view))
-                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.device)),
+                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.preferences)),
                         click()));
     }
 

--- a/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/AdminConfigurableDeviceSettingsFragmentTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/AdminConfigurableDeviceSettingsFragmentTest.java
@@ -45,7 +45,6 @@ public class AdminConfigurableDeviceSettingsFragmentTest extends BaseUITest<AppP
                         click()));
     }
 
-
     @Test
     public void whenDeviceSpecificSettingsIsChangedInAdminMode_checkIfDeviceSettings_isDisabledInNonAdminMode() {
         setCheckboxValue(false);

--- a/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/AdminConfigurableServerSettingsFragmentTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/AdminConfigurableServerSettingsFragmentTest.java
@@ -48,7 +48,6 @@ public class AdminConfigurableServerSettingsFragmentTest extends BaseUITest<AppP
                         click()));
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenServerSettingsIsChangedInAdminMode_checkIfServerSettings_isEnabledInGeneralMode() {
         setCheckboxValue(true);
@@ -76,7 +75,6 @@ public class AdminConfigurableServerSettingsFragmentTest extends BaseUITest<AppP
                 .check(matches(isEnabled()));
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenServerSettingsIsChangedInAdminMode_checkIfServerSettings_isDisabledInGeneralMode() {
         setCheckboxValue(false);

--- a/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/AdminConfigurableServerSettingsFragmentTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/AdminConfigurableServerSettingsFragmentTest.java
@@ -47,7 +47,6 @@ public class AdminConfigurableServerSettingsFragmentTest extends BaseUITest<AppP
                 .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.restrict_server)),
                         click()));
     }
-
     @Test
     public void whenServerSettingsIsChangedInAdminMode_checkIfServerSettings_isEnabledInGeneralMode() {
         setCheckboxValue(true);
@@ -106,7 +105,6 @@ public class AdminConfigurableServerSettingsFragmentTest extends BaseUITest<AppP
     public void after() {
         resetConfiguration();
     }
-
     @Override
     protected Intent getLaunchIntent() {
         Intent intent = new Intent(getContext(), AppPropertiesActivity.class);

--- a/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/AdminConfigurableTablesSettingsFragmentTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/AdminConfigurableTablesSettingsFragmentTest.java
@@ -46,7 +46,6 @@ public class AdminConfigurableTablesSettingsFragmentTest extends BaseUITest<AppP
                         click()));
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenTableSpecificSettingsIsChangedInAdminMode_checkIfTableSettings_isDisabledInNonAdminMode() {
         setCheckboxValue(false);
@@ -63,7 +62,6 @@ public class AdminConfigurableTablesSettingsFragmentTest extends BaseUITest<AppP
 
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenTableSpecificSettingsIsChangedInAdminMode_checkIfTableSettings_isEnabledInNonAdminMode() {
         setCheckboxValue(true);
@@ -100,7 +98,7 @@ public class AdminConfigurableTablesSettingsFragmentTest extends BaseUITest<AppP
         onView(isRoot()).perform(waitFor(1000));
 
         onView(withId(androidx.preference.R.id.recycler_view))
-                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.tool_tables_settings)),
+                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.odkx_tables)),
                         click()));
     }
 

--- a/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/AdminConfigurableTablesSettingsFragmentTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/AdminConfigurableTablesSettingsFragmentTest.java
@@ -40,7 +40,6 @@ public class AdminConfigurableTablesSettingsFragmentTest extends BaseUITest<AppP
         });
         enableAdminMode();
         Espresso.pressBack();
-
         onView(withId(androidx.preference.R.id.recycler_view))
                 .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.admin_tool_tables_settings)),
                         click()));

--- a/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/VerifyUserPermissionTest.java
+++ b/services_app/src/androidTest/java/org/opendatakit/services/preferences/fragments/VerifyUserPermissionTest.java
@@ -39,21 +39,19 @@ public class VerifyUserPermissionTest extends BaseUITest<AppPropertiesActivity> 
 
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenVerifyUserPermissionScreenIsClicked_launchVerifyServerSettingsActivity() {
         onView(withId(androidx.preference.R.id.recycler_view))
-                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.verify_server_settings_start)),
+                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.verify_server_settings_header)),
                         click()));
         intended(hasComponent(VerifyServerSettingsActivity.class.getName()));
     }
 
-    @Ignore // OUTREACHY-BROKEN-TEST
     @Test
     public void whenVerifyUserPermissionIsClicked_configureServerUrl() {
         resetConfiguration();
         onView(withId(androidx.preference.R.id.recycler_view))
-                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.verify_server_settings_start)),
+                .perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(R.string.verify_server_settings_header)),
                         click()));
         onView(withText(R.string.configure_server_settings))
                 .inRoot(isDialog())


### PR DESCRIPTION
# **This is a pull request raised for issue https://github.com/odk-x/tool-suite-X/issues/470**

## **Reason for Fix:**
There are configurable settings available for a normal user of the app and there are configurable settings available for a user with admin privileges. The UI tests for these settings screen was broken following a rework of the settings screen. This PR was raised to fix the broken UI Test for the configurable settings that are available to a user with ADMIN privileges. These tests includes the following:

 -AdminConfigurableServerSettingsFragmentTest.java
 -AdminConfigurableDeviceSettingsFragmentTest.java
 -AdminConfigurableTablesSettingsFragmentTest.java

## **What was changed in these files:**

AdminConfigurableServerSettingsFragmentTest.java
--Nothing changed. this test was fixed when the enableAdminMode(); function in BaseUItest was fixed

AdminConfigurableDeviceSettingsFragmentTest.java
--corrected the reference for the string to be matched.

AdminConfigurableTablesSettingsFragmentTest.java
--corrected the reference for the string to be matched.

# ***Also updated the PR with a fix for VerifyUserPermissionTest.java**

## **What was changed in these files:**

VerifyUserPermissionTest.java
--corrected the reference for the string to be matched.

## ***N/B: Please note that following update of this PR with the fix for VerifyUserPermissionTest.java, this concludes the fixing of all the broken UI tests in the Preferences package. except for the QR code scanner test which has no current implementation.**

![Screenshot 2024-03-29 213306](https://github.com/odk-x/services/assets/95471989/db785240-c693-478d-bbd3-6c5c39d69fe7)
![Screenshot 2024-03-29 213423](https://github.com/odk-x/services/assets/95471989/224a9320-66eb-4b10-ac22-19bd14995702)
![Screenshot 2024-03-29 213601](https://github.com/odk-x/services/assets/95471989/2da24179-e796-43d0-bc52-d48fe4378505)
![Screenshot 2024-03-29 213713](https://github.com/odk-x/services/assets/95471989/b3ef7402-2daf-487a-85d4-19121a0692ef)
