### PR TITLE
fix issue#480:Update Services to fix deprecated ViewModelProviders

### DIFF
--- a/services_app/src/main/java/org/opendatakit/services/preferences/activities/AppPropertiesActivity.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/activities/AppPropertiesActivity.java
@@ -27,9 +27,10 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+
 
 import com.google.android.material.appbar.MaterialToolbar;
 
@@ -109,9 +110,7 @@ public class AppPropertiesActivity extends AppCompatActivity implements
     mAdminMode =
             getIntent().getBooleanExtra(IntentConsts.INTENT_KEY_SETTINGS_IN_ADMIN_MODE, false);
 
-    preferenceViewModel = ViewModelProviders
-            .of(this)
-            .get(PreferenceViewModel.class);
+    preferenceViewModel = new  ViewModelProvider(this).get(PreferenceViewModel.class);
 
     preferenceViewModel.getAdminConfigured().setValue(mAdminConfigured);
     preferenceViewModel.getAdminMode().setValue(mAdminMode);

--- a/services_app/src/main/java/org/opendatakit/services/preferences/fragments/AdminPasswordChallengeFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/fragments/AdminPasswordChallengeFragment.java
@@ -25,7 +25,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
 import androidx.fragment.app.Fragment;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.google.android.material.textfield.TextInputEditText;
 
@@ -57,8 +57,7 @@ public class AdminPasswordChallengeFragment extends Fragment {
          mAppName = appName;
       }
 
-      preferenceViewModel = ViewModelProviders
-          .of(requireActivity())
+      preferenceViewModel = new ViewModelProvider(requireActivity())
           .get(PreferenceViewModel.class);
    }
 

--- a/services_app/src/main/java/org/opendatakit/services/preferences/fragments/AdminPasswordSettingsFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/fragments/AdminPasswordSettingsFragment.java
@@ -19,7 +19,7 @@ import android.os.Bundle;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.preference.Preference;
 import androidx.preference.Preference.OnPreferenceChangeListener;
 import androidx.preference.PreferenceFragmentCompat;
@@ -76,8 +76,7 @@ public class AdminPasswordSettingsFragment extends PreferenceFragmentCompat impl
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
-    preferenceViewModel = ViewModelProviders
-        .of(requireActivity())
+    preferenceViewModel = new ViewModelProvider(requireActivity())
         .get(PreferenceViewModel.class);
   }
 

--- a/services_app/src/main/java/org/opendatakit/services/preferences/fragments/SettingsMenuFragment.java
+++ b/services_app/src/main/java/org/opendatakit/services/preferences/fragments/SettingsMenuFragment.java
@@ -5,7 +5,7 @@ import android.net.Uri;
 import android.os.Bundle;
 
 import androidx.lifecycle.Observer;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
@@ -61,8 +61,7 @@ public class SettingsMenuFragment extends PreferenceFragmentCompat {
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
-    preferenceViewModel = ViewModelProviders
-        .of(requireActivity())
+    preferenceViewModel = new ViewModelProvider(requireActivity())
         .get(PreferenceViewModel.class);
 
     preferenceViewModel.getAdminMode().observe(this, new Observer<Boolean>() {


### PR DESCRIPTION
### This is Pull request raised for issue [odk-x/tool-suite-X#480](https://github.com/odk-x/tool-suite-X/issues/480)
### Reason for fix - Because of viewModelProviders Deprecation
I have changed the viewModelProviders to viewModelProvider in the following files 

- AppProperitesActivity.java
- AdminPasswordChallengeFragment.java
- AdminPasswordSettingsFragment.java
- SettingsMenuFragment.java

