### PR TITLE
Setup CircleCI to store build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,41 +58,46 @@ jobs:
           name: Build Services
           command: ./gradlew assembleSnapshotDebug
 
+      - store_artifacts:
+          name: Store Build Artifacts
+          path: services_app/build/outputs/apk
+
       - persist_to_workspace:
           root: .
           paths:
-            #- build/outputs/apk/snapshot/debug/services_app-snapshot-debug.apk
-            - services_app/build/outputs/apk/snapshot/debug/services_app-snapshot-debug.apk
+            - services_app/build/outputs/apk
+            # - services_app/build/outputs/apk/snapshot/debug/services_app-snapshot-debug.apk
 
-  deploy:
-    docker:
-      - image: cimg/python:3.12.3
-    working_directory: ~/project
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ~/project
-      - run:
-          name: Install Github Releases CLI
-          command: pip install githubrelease
-      - run:
-          name: Create Github Releases and Upload APK
-          command: |
-            APK_FILE="services_app/build/outputs/apk/snapshot/debug/services_app-snapshot-debug.apk"
-            SHORT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)
-            TAG_NAME="snapshot-$SHORT_HASH"
-                        
-            githubrelease release $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME create $TAG_NAME --name $TAG_NAME --body "Automated release by CircleCI"
-            githubrelease asset $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME upload $TAG_NAME $APK_FILE
-        
+
+#  deploy:
+#    docker:
+#      - image: cimg/python:3.12.3
+#    working_directory: ~/project
+#    steps:
+#      - checkout
+#      - attach_workspace:
+#          at: ~/project
+#      - run:
+#          name: Install Github Releases CLI
+#          command: pip install githubrelease
+#      - run:
+#          name: Create Github Releases and Upload APK
+#          command: |
+#            APK_FILE="services_app/build/outputs/apk/snapshot/debug/services_app-snapshot-debug.apk"
+#            SHORT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)
+#            TAG_NAME="snapshot-$SHORT_HASH"
+#
+#            githubrelease release $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME create $TAG_NAME --name $TAG_NAME --body "Automated release by CircleCI"
+#            githubrelease asset $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME upload $TAG_NAME $APK_FILE
+#
 
 workflows:
   build-test-workflow:
     jobs:
       - build
-      - deploy:
-          requires:
-            - build
       - test:
           requires:
             - build
+#      - deploy:
+#          requires:
+#            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,39 +57,13 @@ jobs:
       - run:
           name: Build Services
           command: ./gradlew assembleSnapshotDebug
-
       - store_artifacts:
           name: Store Build Artifacts
           path: services_app/build/outputs/apk
-
       - persist_to_workspace:
           root: .
           paths:
             - services_app/build/outputs/apk
-            # - services_app/build/outputs/apk/snapshot/debug/services_app-snapshot-debug.apk
-
-
-#  deploy:
-#    docker:
-#      - image: cimg/python:3.12.3
-#    working_directory: ~/project
-#    steps:
-#      - checkout
-#      - attach_workspace:
-#          at: ~/project
-#      - run:
-#          name: Install Github Releases CLI
-#          command: pip install githubrelease
-#      - run:
-#          name: Create Github Releases and Upload APK
-#          command: |
-#            APK_FILE="services_app/build/outputs/apk/snapshot/debug/services_app-snapshot-debug.apk"
-#            SHORT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)
-#            TAG_NAME="snapshot-$SHORT_HASH"
-#
-#            githubrelease release $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME create $TAG_NAME --name $TAG_NAME --body "Automated release by CircleCI"
-#            githubrelease asset $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME upload $TAG_NAME $APK_FILE
-#
 
 workflows:
   build-test-workflow:
@@ -98,6 +72,3 @@ workflows:
       - test:
           requires:
             - build
-#      - deploy:
-#          requires:
-#            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,13 +55,44 @@ jobs:
       - android/save-gradle-cache:
           cache-prefix: v1
       - run:
-          name: Build Common
+          name: Build Services
           command: ./gradlew assembleSnapshotDebug
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            #- build/outputs/apk/snapshot/debug/services_app-snapshot-debug.apk
+            - services_app/build/outputs/apk/snapshot/debug/services_app-snapshot-debug.apk
+
+  deploy:
+    docker:
+      - image: cimg/python:3.12.3
+    working_directory: ~/project
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Install Github Releases CLI
+          command: pip install githubrelease
+      - run:
+          name: Create Github Releases and Upload APK
+          command: |
+            APK_FILE="services_app/build/outputs/apk/snapshot/debug/services_app-snapshot-debug.apk"
+            SHORT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)
+            TAG_NAME="snapshot-$SHORT_HASH"
+                        
+            githubrelease release $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME create $TAG_NAME --name $TAG_NAME --body "Automated release by CircleCI"
+            githubrelease asset $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME upload $TAG_NAME $APK_FILE
+        
 
 workflows:
   build-test-workflow:
     jobs:
       - build
+      - deploy:
+          requires:
+            - build
       - test:
           requires:
             - build


### PR DESCRIPTION
This adds a config to deploy build artifacts to GitHub Releases which can be used for the Tables tests.